### PR TITLE
Add system identity and default skills to RAG context

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Openheim is built in Rust from the ground up:
 - **Tool execution** — built-in shell, file read, and file write tools. Trait-based, so you can add your own.
 - **MCP (Model Context Protocol)** — connect external MCP servers (stdio or Streamable HTTP) and their tools are automatically exposed to the LLM as `{server_name}__{tool_name}`.
 - **Conversation memory** — conversations (including full tool call history) persist to disk and resume across sessions
-- **Skills** — drop a markdown file into `~/.openheim/skills/` and it's prepended to the system prompt. ACP clients can also pass skills per-session via `_meta`.
+- **System identity** — edit `~/.openheim/system.md` to define how the agent presents itself. Required at startup (created by `openheim init`).
+- **Skills** — drop a markdown file into `~/.openheim/skills/` and it's injected into the system prompt. Set `default_skills` in config to auto-load skills every session; pass `--skills` for per-session additions. ACP clients can also pass skills per-session via `_meta`.
 - **ACP transport** — implements the [Agent Client Protocol](https://github.com/block/agent-client-protocol) over stdio (for editor integrations) and WebSocket (for remote clients), with real-time streaming of message chunks and tool calls
 - **Unified WebSocket** — single multiplexed `WS /ws` connection carries both ACP agent traffic (sessions, streaming, tool calls) and filesystem operations (file CRUD, live watching) via channel envelopes
 - **Retry with backoff** — transient failures (429s, 5xx, network errors) are retried automatically with exponential backoff
@@ -79,11 +80,12 @@ cargo build --release
 ### Configure
 
 ```bash
-# Generate the default config
+# Generate the default config and system.md
 cargo run -- init
 
-# Edit it
+# Edit them
 vim ~/.openheim/config.toml
+vim ~/.openheim/system.md
 ```
 
 Example config:
@@ -91,6 +93,9 @@ Example config:
 ```toml
 default_provider = "anthropic"
 max_iterations = 10
+
+# Skills loaded in every new session automatically (no --skills flag needed)
+# default_skills = ["rules"]
 
 [providers.anthropic]
 api_base = "https://api.anthropic.com/v1"
@@ -170,15 +175,46 @@ Conversations are saved to `~/.openheim/history/` as JSON after every run.
 
 ---
 
-## Skills
+## Agent identity and skills
 
-Skills are markdown files in `~/.openheim/skills/`. When loaded, their content is injected into the system prompt before the conversation starts.
+### `~/.openheim/system.md`
 
-Use them to give the agent a persona, a set of coding standards, domain knowledge, or anything you'd otherwise paste into the system prompt every time.
+This file defines the agent's base identity. It is loaded on every session and is required — run `openheim init` to create it, then edit it freely.
+
+```markdown
+You are a senior software engineer who writes clean, idiomatic code.
+You prefer simple solutions and ask clarifying questions before making large changes.
+```
+
+### Skills
+
+Skills are markdown files in `~/.openheim/skills/`. They are injected into the system prompt after the identity block.
 
 ```bash
-# Run the REPL with specific skills loaded
+# Run with specific skills for this session
 cargo run -- --skills rust,debugging
+
+# Always load certain skills (set in config.toml)
+# default_skills = ["rules", "concise"]
+```
+
+The system message the LLM receives is assembled in this order:
+
+```
+You are a general purpose multiprovider LLM agent.
+
+---
+
+The user has given you the following identity:
+
+<system.md content>
+
+---
+
+These are the skills you have mastered:
+
+### rust
+<rust.md content>
 ```
 
 ACP clients (Zed, Claude Code, etc.) can pass skills per-session by including a `skills` array in the `_meta` field of the `NewSession` request — no flag needed on the server side.
@@ -284,7 +320,7 @@ src/
   mcp/              MCP (Model Context Protocol) client integration
     client.rs       MCP server connection (stdio + Streamable HTTP)
     tool_handler.rs  Adapts MCP tools to the ToolHandler trait
-  rag/              Conversation history, prompt builder, and skills manager
+  rag/              Conversation history, prompt builder, skills manager, and system identity
   acp/              ACP agent core — session state and protocol handling
   transport/
     stdio.rs        ACP-over-stdio transport (for editor integrations)

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Openheim is built in Rust from the ground up:
 - **Tool execution** — built-in shell, file read, and file write tools. Trait-based, so you can add your own.
 - **MCP (Model Context Protocol)** — connect external MCP servers (stdio or Streamable HTTP) and their tools are automatically exposed to the LLM as `{server_name}__{tool_name}`.
 - **Conversation memory** — conversations (including full tool call history) persist to disk and resume across sessions
-- **System identity** — edit `~/.openheim/system.md` to define how the agent presents itself. Required at startup (created by `openheim init`).
+- **System identity** — edit `~/.openheim/system.md` to define how the agent presents itself. Required when preparing a session (created by `openheim init`).
 - **Skills** — drop a markdown file into `~/.openheim/skills/` and it's injected into the system prompt. Set `default_skills` in config to auto-load skills every session; pass `--skills` for per-session additions. ACP clients can also pass skills per-session via `_meta`.
 - **ACP transport** — implements the [Agent Client Protocol](https://github.com/block/agent-client-protocol) over stdio (for editor integrations) and WebSocket (for remote clients), with real-time streaming of message chunks and tool calls
 - **Unified WebSocket** — single multiplexed `WS /ws` connection carries both ACP agent traffic (sessions, streaming, tool calls) and filesystem operations (file CRUD, live watching) via channel envelopes
@@ -81,7 +81,7 @@ cargo build --release
 
 ```bash
 # Generate the default config and system.md
-cargo run -- init
+openheim init
 
 # Edit them
 vim ~/.openheim/config.toml
@@ -134,26 +134,26 @@ models = ["llama3", "mistral", "codellama"]
 
 ```bash
 # Interactive REPL (default — no subcommand)
-cargo run
+openheim
 
 # Load skills in the REPL
-cargo run -- --skills rust,debugging
+openheim --skills rust,debugging
 
 # Single headless prompt, streams to stdout
-cargo run -- run "List the files in the current directory"
+openheim run "List the files in the current directory"
 
 # Single headless prompt with a model override
-cargo run -- run "Hello" --model gpt-4o
+openheim run "Hello" --model gpt-4o
 
 # ACP stdio agent (for Zed, Claude Code, and other ACP clients)
-cargo run -- acp
+openheim acp
 
 # ACP-over-WebSocket server
-cargo run -- serve
-cargo run -- serve --host 0.0.0.0 --port 1217
+openheim serve
+openheim serve --host 0.0.0.0 --port 1217
 
 # Initialize config
-cargo run -- init
+openheim init
 ```
 
 ---
@@ -179,7 +179,7 @@ Conversations are saved to `~/.openheim/history/` as JSON after every run.
 
 ### `~/.openheim/system.md`
 
-This file defines the agent's base identity. It is loaded on every session and is required — run `openheim init` to create it, then edit it freely.
+This file defines the agent's base identity. It is loaded when preparing each session (via `prepare()` / session setup) and is required — run `openheim init` to create it, then edit it freely.
 
 ```markdown
 You are a senior software engineer who writes clean, idiomatic code.
@@ -192,7 +192,7 @@ Skills are markdown files in `~/.openheim/skills/`. They are injected into the s
 
 ```bash
 # Run with specific skills for this session
-cargo run -- --skills rust,debugging
+openheim --skills rust,debugging
 
 # Always load certain skills (set in config.toml)
 # default_skills = ["rules", "concise"]
@@ -223,7 +223,7 @@ ACP clients (Zed, Claude Code, etc.) can pass skills per-session by including a 
 
 ## Server mode
 
-Start with `cargo run -- serve` (defaults to `0.0.0.0:1217`).
+Start with `openheim serve` (defaults to `0.0.0.0:1217`).
 
 The server speaks the [Agent Client Protocol](https://github.com/block/agent-client-protocol) over WebSocket and exposes a multiplexed WS endpoint plus REST API routes:
 
@@ -334,7 +334,7 @@ src/
 ## Development
 
 ```bash
-RUST_LOG=debug cargo run -- run "test"
+RUST_LOG=debug openheim run "test"
 cargo test
 cargo fmt --check
 cargo clippy

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,10 +44,11 @@ src/
 ├── error.rs            Unified Error / Result types
 │
 ├── rag/                Retrieval-Augmented Generation utilities
-│   ├── mod.rs          RagContext — history + skills bundled together
+│   ├── mod.rs          RagContext — history + skills + system identity
 │   ├── history.rs      HistoryManager — conversation persistence
 │   ├── skills.rs       SkillsManager — Markdown skill files
-│   └── prompt.rs       PromptBuilder — injects skills as a system message
+│   ├── system.rs       SystemLoader — reads ~/.openheim/system.md
+│   └── prompt.rs       PromptBuilder — assembles structured system message
 │
 ├── tools/              Tool abstraction and built-in implementations
 │   ├── mod.rs          ToolHandler / ToolExecutor traits, SystemToolExecutor
@@ -108,8 +109,10 @@ User / Client
 │            rag::RagContext::prepare         │
 │                                             │
 │  1. Load conversation from disk (history)   │
-│  2. Load skill files by name                │
-│  3. Build PromptBuilder (system message)    │
+│  2. Load ~/.openheim/system.md (identity)   │
+│  3. Merge default_skills + session skills   │
+│  4. Load skill files by name                │
+│  5. Build PromptBuilder (system message)    │
 │                                             │
 │  Returns: (Conversation, PromptBuilder)     │
 └────────────────────┬────────────────────────┘
@@ -160,7 +163,8 @@ All persistence lives under `~/.openheim/` by default.
 
 ```
 ~/.openheim/
-├── config.toml              Agent configuration (providers, MCP servers, …)
+├── config.toml              Agent configuration (providers, MCP servers, default_skills, …)
+├── system.md                Agent identity — loaded on every session (required)
 ├── history/
 │   ├── {uuid}.json          One file per conversation
 │   └── …
@@ -169,7 +173,7 @@ All persistence lives under `~/.openheim/` by default.
     └── …
 ```
 
-`HistoryManager` reads and writes conversation JSON files. `SkillsManager` reads `.md` files from the skills directory. Both paths are configurable at construction time, which is how the test suite uses temporary directories.
+`SystemLoader` reads `system.md` on every `prepare()` call — missing file is a hard error (run `openheim init` to create it). `HistoryManager` reads and writes conversation JSON files. `SkillsManager` reads `.md` files from the skills directory. Both history and skills paths are configurable at construction time, which is how the test suite uses temporary directories.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,11 +14,15 @@ cargo run -- init
 |---|---|---|---|
 | `default_provider` | string | — | Provider to use when no `--model` override is given (must match a key under `[providers]`) |
 | `max_iterations` | integer | `10` | Maximum number of agent loop iterations per prompt before stopping |
+| `default_skills` | string[] | `[]` | Skills loaded automatically in every new session. Merged with per-session `--skills`; defaults appear first, duplicates removed. |
 | `theme_color` | string | `"white"` | TUI accent color. Valid values: `white`, `gray`, `blue`, `cyan`, `magenta`, `green`, `yellow`, `red`, `pink`. Can also be changed at runtime with `:theme` |
 
 ```toml
 default_provider = "anthropic"
 max_iterations = 20
+
+# Always load these skills without passing --skills each time
+default_skills = ["rules", "concise"]
 ```
 
 ---

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3,7 +3,7 @@
 Openheim loads its configuration from `~/.openheim/config.toml`. Generate a default file with:
 
 ```bash
-cargo run -- init
+openheim init
 ```
 
 ---

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,10 +1,33 @@
-# Skills
+# Skills & Agent Identity
 
-Skills are Markdown files that inject system-level instructions into every LLM request in a session. They let you shape the agent's behaviour — tone, domain expertise, constraints, output format — without touching code or configuration.
+This document covers two related concepts:
+
+- **System identity** (`~/.openheim/system.md`) — the agent's base character, loaded on every session.
+- **Skills** (`~/.openheim/skills/*.md`) — domain-specific instructions injected on demand.
 
 ---
 
-## Where skills live
+## Agent Identity (`system.md`)
+
+`~/.openheim/system.md` defines who the agent is. It is loaded at the start of every session and is **required** — openheim will error on startup if the file is missing.
+
+Run `openheim init` to create it with a default starting point, then edit it to match how you want the agent to behave:
+
+```markdown
+You are a senior software engineer specialising in Rust and distributed systems.
+You write clean, idiomatic code and prefer simple solutions over clever ones.
+Ask clarifying questions before making large changes.
+```
+
+The identity is placed at the top of the system message, before any skills.
+
+---
+
+## Skills
+
+Skills are Markdown files that inject domain-specific instructions into the system prompt. They let you shape the agent's behaviour — tone, domain expertise, constraints, output format — without touching code or configuration.
+
+### Where skills live
 
 Skills are stored as `.md` files in `~/.openheim/skills/`:
 
@@ -19,23 +42,32 @@ The filename (without extension) is the skill name. Names are case-sensitive and
 
 ---
 
-## How they work
+## How the system message is assembled
 
-When a session starts with one or more skills, `SkillsManager` reads each file and passes the content to `PromptBuilder`. Before each LLM call, the builder prepends a single system message containing all active skills, joined by `---` separators:
+When a session has an identity and skills, the LLM receives a single system message structured like this:
 
 ```
-[System message]
-## Skill: rust
-
-You are an expert Rust programmer. Always prefer idiomatic Rust…
+You are a general purpose multiprovider LLM agent.
 
 ---
 
-## Skill: tdd
+The user has given you the following identity:
 
-Write tests first. Every function should have at least one test…
+<system.md content>
 
-[Conversation history follows]
+---
+
+These are the skills you have mastered:
+
+### rust
+
+<rust.md content>
+
+---
+
+### tdd
+
+<tdd.md content>
 ```
 
 The system message is reconstructed on every LLM call in the session, so it is always present regardless of how long the conversation runs.
@@ -72,21 +104,23 @@ This skill is about systems programming. The assistant knows Rust and C.
 
 ## Enabling skills
 
-### Via CLI
+### Default skills (loaded every session)
+
+Set `default_skills` in `~/.openheim/config.toml` to load skills automatically in every new session — no `--skills` flag needed:
+
+```toml
+default_skills = ["rules", "concise"]
+```
+
+Default skills are merged with any per-session skills. Duplicates are deduplicated; defaults always appear first.
+
+### Per-session via CLI
 
 Pass `--skills` as a comma-separated list of skill names:
 
 ```bash
 openheim --skills rust,tdd
 openheim run --skills concise "Summarise the project structure"
-```
-
-### Via configuration
-
-Set skills globally in `~/.openheim/config.toml` so they apply to every session:
-
-```toml
-skills = ["rust", "concise"]
 ```
 
 ### Via the Rust library
@@ -108,9 +142,6 @@ Skills are persisted in the conversation metadata (`ConversationMeta.skills`), s
 ## Listing available skills
 
 ```bash
-# CLI
-openheim --skills ""   # lists available skills on startup (TUI)
-
 # API (REST when running openheim serve)
 curl http://localhost:1217/api/skills
 # → ["concise","rust","tdd"]
@@ -125,7 +156,15 @@ let skills = client.rag().skills.list_skills()?;
 
 ---
 
-## Example skills
+## Example files
+
+### `~/.openheim/system.md`
+
+```markdown
+You are a pragmatic software engineer who writes clean, well-tested code.
+You prefer simple solutions and always consider the maintenance burden of your suggestions.
+When you are uncertain, say so rather than guessing.
+```
 
 ### `~/.openheim/skills/concise.md`
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -239,6 +239,7 @@ pub struct OpenheimBuilder {
     timeout_secs: Option<u64>,
     max_tokens: Option<u32>,
     mcp_servers: BTreeMap<String, McpServerConfig>,
+    default_skills: Vec<String>,
 }
 
 impl OpenheimBuilder {
@@ -297,6 +298,12 @@ impl OpenheimBuilder {
         self
     }
 
+    /// Skills loaded automatically in every new session.
+    pub fn default_skills(mut self, skills: Vec<String>) -> Self {
+        self.default_skills = skills;
+        self
+    }
+
     /// Build the client, connecting to MCP servers and initialising the agent state.
     pub async fn build(self) -> Result<OpenheimClient> {
         let (agent_config, mut app_config) = if self.provider.is_some()
@@ -312,6 +319,7 @@ impl OpenheimBuilder {
                 self.max_iterations,
                 self.timeout_secs,
                 self.max_tokens,
+                self.default_skills.clone(),
             )
         } else {
             let app_config = match self.config_path {
@@ -336,12 +344,18 @@ impl OpenheimBuilder {
             app_config.mcp_servers.insert(name, cfg);
         }
 
+        // Apply builder default_skills for the file-based path (programmatic path sets them directly)
+        if !self.default_skills.is_empty() {
+            app_config.default_skills = self.default_skills;
+        }
+
         let rag = RagContext::new(app_config.default_skills.clone())?;
         let state = Arc::new(AgentState::new(agent_config, app_config, rag).await?);
         Ok(OpenheimClient { state })
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_programmatic(
     provider: Option<String>,
     api_key: Option<String>,
@@ -350,6 +364,7 @@ fn build_programmatic(
     max_iterations: Option<usize>,
     timeout_secs: Option<u64>,
     max_tokens: Option<u32>,
+    default_skills: Vec<String>,
 ) -> (AgentConfig, AppConfig) {
     let provider = provider.unwrap_or_else(|| "openai".to_string());
     let api_base = api_base.unwrap_or_else(|| default_api_base(&provider));
@@ -378,7 +393,7 @@ fn build_programmatic(
         theme_color: None,
         providers,
         mcp_servers: BTreeMap::new(),
-        default_skills: vec![],
+        default_skills,
     };
 
     let agent_config = AgentConfig {

--- a/src/client.rs
+++ b/src/client.rs
@@ -336,7 +336,7 @@ impl OpenheimBuilder {
             app_config.mcp_servers.insert(name, cfg);
         }
 
-        let rag = RagContext::new()?;
+        let rag = RagContext::new(app_config.default_skills.clone())?;
         let state = Arc::new(AgentState::new(agent_config, app_config, rag).await?);
         Ok(OpenheimClient { state })
     }
@@ -378,6 +378,7 @@ fn build_programmatic(
         theme_color: None,
         providers,
         mcp_servers: BTreeMap::new(),
+        default_skills: vec![],
     };
 
     let agent_config = AgentConfig {

--- a/src/config/client.rs
+++ b/src/config/client.rs
@@ -121,6 +121,7 @@ mod tests {
             theme_color: None,
             providers,
             mcp_servers: BTreeMap::new(),
+            default_skills: vec![],
         }
     }
 

--- a/src/config/config.toml.default
+++ b/src/config/config.toml.default
@@ -7,6 +7,10 @@ default_provider = "openai"
 # Maximum number of agent iterations (can be overridden with --max-iterations)
 max_iterations = 10
 
+# Skills loaded automatically in every new session (no --skills flag needed).
+# Add skill names matching files in ~/.openheim/skills/{name}.md
+# default_skills = ["rules"]
+
 # --- Provider Configuration ---
 #
 # The provider name determines which API client is used:

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -23,20 +23,37 @@ pub fn config_path() -> Result<PathBuf> {
     Ok(config_dir()?.join("config.toml"))
 }
 
+const DEFAULT_SYSTEM_MD: &str = "You are Openheim, a multipurpose, multiprovider LLM agent.";
+
 /// Initialize the config file at ~/.openheim/config.toml with the default template.
-/// Returns the path written to.
+/// Also writes ~/.openheim/system.md if it does not already exist.
+/// Returns the path of the config file written.
+///
+/// Errors if `config.toml` already exists. `system.md` is written regardless —
+/// so existing users who already have a config can still run `openheim init` to
+/// get their `system.md` created.
 pub fn init_config() -> Result<PathBuf> {
     let dir = config_dir()?;
     std::fs::create_dir_all(&dir)?;
-    let path = dir.join("config.toml");
-    if path.exists() {
+
+    // Always write system.md first so existing users who re-run `init` get it
+    // even though config.toml already exists and will cause an early return below.
+    let system_path = dir.join("system.md");
+    if !system_path.exists() {
+        std::fs::write(&system_path, DEFAULT_SYSTEM_MD)?;
+    }
+
+    let config_path = dir.join("config.toml");
+    if config_path.exists() {
         return Err(Error::config(format!(
-            "Config file already exists at {}",
-            path.display()
+            "Config file already exists at {}. system.md has been created at {}.",
+            config_path.display(),
+            system_path.display()
         )));
     }
-    std::fs::write(&path, DEFAULT_CONFIG)?;
-    Ok(path)
+    std::fs::write(&config_path, DEFAULT_CONFIG)?;
+
+    Ok(config_path)
 }
 
 /// Load AppConfig from a specific path

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -39,16 +39,22 @@ pub fn init_config() -> Result<PathBuf> {
     // Always write system.md first so existing users who re-run `init` get it
     // even though config.toml already exists and will cause an early return below.
     let system_path = dir.join("system.md");
-    if !system_path.exists() {
+    let system_written = !system_path.exists();
+    if system_written {
         std::fs::write(&system_path, DEFAULT_SYSTEM_MD)?;
     }
 
     let config_path = dir.join("config.toml");
     if config_path.exists() {
+        let system_note = if system_written {
+            format!("system.md has been created at {}.", system_path.display())
+        } else {
+            format!("system.md is available at {}.", system_path.display())
+        };
         return Err(Error::config(format!(
-            "Config file already exists at {}. system.md has been created at {}.",
+            "Config file already exists at {}. {}",
             config_path.display(),
-            system_path.display()
+            system_note
         )));
     }
     std::fs::write(&config_path, DEFAULT_CONFIG)?;

--- a/src/config/resolve.rs
+++ b/src/config/resolve.rs
@@ -149,6 +149,7 @@ mod tests {
             theme_color: None,
             providers,
             mcp_servers: BTreeMap::new(),
+            default_skills: vec![],
         }
     }
 
@@ -189,6 +190,7 @@ mod tests {
             theme_color: None,
             providers: BTreeMap::new(),
             mcp_servers: BTreeMap::new(),
+            default_skills: vec![],
         };
         let err = config.resolve(None).unwrap_err();
         assert!(err.to_string().contains("nonexistent"));

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -38,6 +38,9 @@ pub struct AppConfig {
     pub providers: BTreeMap<String, ProviderConfig>,
     #[serde(default)]
     pub mcp_servers: BTreeMap<String, McpServerConfig>,
+    /// Skills loaded automatically in every new session (merged with --skills at runtime).
+    #[serde(default)]
+    pub default_skills: Vec<String>,
 }
 
 /// Configuration for a single MCP server connection.

--- a/src/mcp/client.rs
+++ b/src/mcp/client.rs
@@ -42,7 +42,9 @@ impl McpClient {
             for (k, v) in &config.env {
                 cmd.env(k, v);
             }
-            let transport = TokioChildProcess::new(cmd)
+            let (transport, _) = TokioChildProcess::builder(cmd)
+                .stderr(std::process::Stdio::null())
+                .spawn()
                 .map_err(|e| Error::Other(format!("MCP spawn '{}' failed: {}", name, e)))?;
             let service = ().serve(transport).await.map_err(|e| {
                 Error::Other(format!("MCP stdio connect to '{}' failed: {}", name, e))

--- a/src/rag/mod.rs
+++ b/src/rag/mod.rs
@@ -86,8 +86,8 @@ impl RagContext {
 /// Merge `defaults` with `session` skills, preserving order and deduplicating.
 /// Defaults come first; session skills are appended only if not already present.
 fn merge_skills(defaults: &[String], session: &[String]) -> Vec<String> {
-    let mut merged = defaults.to_vec();
-    for s in session {
+    let mut merged = Vec::new();
+    for s in defaults.iter().chain(session.iter()) {
         if !merged.contains(s) {
             merged.push(s.clone());
         }
@@ -116,6 +116,13 @@ mod tests {
     #[test]
     fn merge_skills_empty_session() {
         let merged = merge_skills(&["rules".to_string()], &[]);
+        assert_eq!(merged, vec!["rules"]);
+    }
+
+    #[test]
+    fn merge_skills_deduplicates_within_defaults() {
+        let defaults = vec!["rules".to_string(), "rules".to_string()];
+        let merged = merge_skills(&defaults, &[]);
         assert_eq!(merged, vec!["rules"]);
     }
 }

--- a/src/rag/mod.rs
+++ b/src/rag/mod.rs
@@ -3,10 +3,12 @@
 pub mod history;
 pub mod prompt;
 pub mod skills;
+pub mod system;
 
 pub use history::{Conversation, ConversationMeta, HistoryManager};
 pub use prompt::PromptBuilder;
 pub use skills::SkillsManager;
+pub use system::SystemLoader;
 
 use crate::error::Result;
 use uuid::Uuid;
@@ -18,22 +20,33 @@ pub struct RagContext {
     pub history: HistoryManager,
     /// Named skill files loaded from `~/.openheim/skills/`.
     pub skills: SkillsManager,
+    /// System identity loaded from `~/.openheim/system.md`.
+    pub system: SystemLoader,
+    /// Skills included in every new session (from `default_skills` in config).
+    default_skills: Vec<String>,
 }
 
 impl RagContext {
-    /// Initialise history and skills from the default openheim data directory.
-    pub fn new() -> Result<Self> {
+    /// Initialise history, skills, and system identity from the default openheim data directory.
+    ///
+    /// `default_skills` are merged with any per-session skills on each new conversation.
+    pub fn new(default_skills: Vec<String>) -> Result<Self> {
         Ok(Self {
             history: HistoryManager::new()?,
             skills: SkillsManager::new()?,
+            system: SystemLoader::new()?,
+            default_skills,
         })
     }
 
     /// Load or create a conversation and build the prompt context for an agent turn.
     ///
     /// Returns the resolved [`Conversation`] and a [`PromptBuilder`] already populated
-    /// with any requested skills. When `chat_id` refers to an existing conversation the
-    /// skills stored on that conversation take precedence over `skill_names`.
+    /// with the system identity and any requested skills.
+    ///
+    /// For **new** conversations, `default_skills` are merged with `skill_names` (defaults
+    /// first, deduplicated) and persisted on the conversation. For **existing** conversations
+    /// the stored skill list is used as-is, preserving the state from when the session began.
     pub fn prepare(
         &self,
         chat_id: Option<Uuid>,
@@ -41,26 +54,68 @@ impl RagContext {
         model: Option<String>,
         provider: Option<String>,
     ) -> Result<(Conversation, PromptBuilder)> {
+        // Always pass merged skills to resolve_conversation. For existing conversations
+        // the parameter is ignored (stored list wins); for new ones it gets persisted.
+        let merged_skills = merge_skills(&self.default_skills, skill_names);
+
         let conversation =
             self.history
-                .resolve_conversation(chat_id, model, provider, skill_names.to_vec())?;
+                .resolve_conversation(chat_id, model, provider, merged_skills)?;
 
         let mut builder = PromptBuilder::new();
 
-        // Load skills: use conversation's stored skills if continuing, otherwise use provided ones
-        let skills_to_load = if chat_id.is_some() && !conversation.meta.skills.is_empty() {
-            &conversation.meta.skills
-        } else {
-            skill_names
-        };
+        // Always inject the system identity as the first layer.
+        let system_content = self.system.load()?;
+        tracing::debug!(chars = system_content.len(), "prepare: loaded system.md");
+        builder.set_system(system_content);
 
-        if !skills_to_load.is_empty() {
-            let loaded = self.skills.load_skills(skills_to_load)?;
+        // Load skills from the conversation's stored list (already contains merged
+        // defaults for new conversations, or the original set for existing ones).
+        if !conversation.meta.skills.is_empty() {
+            let loaded = self.skills.load_skills(&conversation.meta.skills)?;
             for (name, content) in &loaded {
+                tracing::debug!(skill = %name, "prepare: loaded skill");
                 builder.add_skill(name, content);
             }
         }
 
         Ok((conversation, builder))
+    }
+}
+
+/// Merge `defaults` with `session` skills, preserving order and deduplicating.
+/// Defaults come first; session skills are appended only if not already present.
+fn merge_skills(defaults: &[String], session: &[String]) -> Vec<String> {
+    let mut merged = defaults.to_vec();
+    for s in session {
+        if !merged.contains(s) {
+            merged.push(s.clone());
+        }
+    }
+    merged
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn merge_skills_defaults_first_no_duplicates() {
+        let defaults = vec!["rules".to_string(), "coding".to_string()];
+        let session = vec!["coding".to_string(), "rust".to_string()];
+        let merged = merge_skills(&defaults, &session);
+        assert_eq!(merged, vec!["rules", "coding", "rust"]);
+    }
+
+    #[test]
+    fn merge_skills_empty_defaults() {
+        let merged = merge_skills(&[], &["rust".to_string()]);
+        assert_eq!(merged, vec!["rust"]);
+    }
+
+    #[test]
+    fn merge_skills_empty_session() {
+        let merged = merge_skills(&["rules".to_string()], &[]);
+        assert_eq!(merged, vec!["rules"]);
     }
 }

--- a/src/rag/prompt.rs
+++ b/src/rag/prompt.rs
@@ -52,11 +52,8 @@ impl PromptBuilder {
     /// <skill content>
     /// ```
     pub fn build(&self, history: &[Message]) -> Vec<Message> {
-        let identity = self
-            .system_identity
-            .as_deref()
-            .map(str::trim)
-            .filter(|s| !s.is_empty());
+        let orig = self.system_identity.as_deref();
+        let identity = orig.filter(|s| !s.trim().is_empty());
         let has_content = identity.is_some() || !self.skills.is_empty();
 
         if !has_content {

--- a/src/rag/prompt.rs
+++ b/src/rag/prompt.rs
@@ -1,16 +1,18 @@
 use crate::core::models::{Message, Role};
 
-/// Builds an LLM message sequence by prepending skill content as a system message.
+/// Builds an LLM message sequence by prepending a structured system message.
 ///
-/// Skills are accumulated with [`add_skill`] and combined into a single system
-/// message joined by `---` separators. That message is inserted at position 0,
-/// followed by the existing conversation history.
+/// The system message is assembled from an optional identity (from `system.md`)
+/// and any number of named skills, laid out in a consistent template so the
+/// model always understands what it is, what identity it has been given, and
+/// what skills it has been asked to master.
 ///
-/// If no skills have been added, [`build`] returns the history unchanged with no
-/// system message prepended.
+/// If neither identity nor skills have been registered, no system message is
+/// prepended and `history` is returned unchanged.
 #[derive(Default)]
 pub struct PromptBuilder {
-    system_parts: Vec<String>,
+    system_identity: Option<String>,
+    skills: Vec<(String, String)>,
 }
 
 impl PromptBuilder {
@@ -18,34 +20,85 @@ impl PromptBuilder {
         Self::default()
     }
 
-    /// Registers a skill to be included in the system message.
-    ///
-    /// Each call appends a `## Skill: {name}` section. Multiple skills are joined
-    /// with `\n\n---\n\n` when [`build`] is called.
+    /// Sets the system identity loaded from `system.md`.
+    pub fn set_system(&mut self, content: String) {
+        self.system_identity = Some(content);
+    }
+
+    /// Registers a named skill to include in the system message.
     pub fn add_skill(&mut self, name: &str, content: &str) {
-        self.system_parts
-            .push(format!("## Skill: {}\n\n{}", name, content));
+        self.skills.push((name.to_string(), content.to_string()));
     }
 
     /// Constructs the full message list for an LLM request.
     ///
-    /// Prepends a system message containing all registered skill sections to
-    /// `history`. If no skills have been registered, `history` is returned as-is
-    /// with no system message added.
+    /// When there is substantive content (non-blank identity or at least one
+    /// skill), a `Role::System` message is inserted at position 0 using the
+    /// template below. Otherwise `history` is returned unchanged.
+    ///
+    /// ```text
+    /// You are a general purpose multiprovider LLM agent.
+    ///
+    /// The user has given you the following identity:
+    ///
+    /// <system.md content>
+    ///
+    /// ---
+    ///
+    /// These are the skills you have mastered:
+    ///
+    /// ### <skill name>
+    ///
+    /// <skill content>
+    /// ```
     pub fn build(&self, history: &[Message]) -> Vec<Message> {
-        let mut messages = Vec::new();
+        let identity = self
+            .system_identity
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty());
+        let has_content = identity.is_some() || !self.skills.is_empty();
 
-        if !self.system_parts.is_empty() {
-            let system_content = self.system_parts.join("\n\n---\n\n");
-            messages.push(Message {
-                role: Role::System,
-                content: Some(system_content),
-                tool_calls: None,
-                tool_call_id: None,
-                tool_name: None,
-                is_error: false,
-            });
+        if !has_content {
+            return history.to_vec();
         }
+
+        let mut sections: Vec<String> = Vec::new();
+
+        sections.push("You are a general purpose multiprovider LLM agent.".to_string());
+
+        if let Some(id) = identity {
+            sections.push(format!(
+                "The user has given you the following identity:\n\n{id}"
+            ));
+        }
+
+        if !self.skills.is_empty() {
+            let skill_blocks: Vec<String> = self
+                .skills
+                .iter()
+                .map(|(name, content)| format!("### {name}\n\n{content}"))
+                .collect();
+            sections.push(format!(
+                "These are the skills you have mastered:\n\n{}",
+                skill_blocks.join("\n\n---\n\n")
+            ));
+        }
+
+        let system_content = sections.join("\n\n---\n\n");
+        tracing::debug!(
+            len = system_content.len(),
+            "build: system message assembled"
+        );
+
+        let mut messages = vec![Message {
+            role: Role::System,
+            content: Some(system_content),
+            tool_calls: None,
+            tool_call_id: None,
+            tool_name: None,
+            is_error: false,
+        }];
 
         messages.extend_from_slice(history);
         messages
@@ -57,42 +110,84 @@ mod tests {
     use super::*;
 
     #[test]
-    fn build_with_no_skills_returns_history_unchanged() {
+    fn build_with_nothing_returns_history_unchanged() {
         let builder = PromptBuilder::new();
         let history = vec![Message::user("hello".into())];
         let result = builder.build(&history);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].role, Role::User);
-        assert_eq!(result[0].content.as_deref(), Some("hello"));
     }
 
     #[test]
-    fn build_with_one_skill_prepends_system_message() {
+    fn empty_system_identity_is_ignored() {
         let mut builder = PromptBuilder::new();
-        builder.add_skill("coding", "You are a coding assistant.");
-        let history = vec![Message::user("help".into())];
+        builder.set_system("   ".into());
+        let history = vec![Message::user("hi".into())];
         let result = builder.build(&history);
-
-        assert_eq!(result.len(), 2);
-        assert_eq!(result[0].role, Role::System);
-        let content = result[0].content.as_deref().unwrap();
-        assert!(content.contains("## Skill: coding"));
-        assert!(content.contains("You are a coding assistant."));
-        assert_eq!(result[1].role, Role::User);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].role, Role::User);
     }
 
     #[test]
-    fn build_with_multiple_skills_joins_with_separator() {
+    fn set_system_alone_produces_structured_message() {
         let mut builder = PromptBuilder::new();
-        builder.add_skill("skill_a", "Content A");
-        builder.add_skill("skill_b", "Content B");
-        let history = vec![Message::user("test".into())];
-        let result = builder.build(&history);
+        builder.set_system("I am a helpful agent.".into());
+        let result = builder.build(&[Message::user("hi".into())]);
 
         assert_eq!(result.len(), 2);
         let content = result[0].content.as_deref().unwrap();
-        assert!(content.contains("## Skill: skill_a"));
-        assert!(content.contains("## Skill: skill_b"));
+        assert!(content.contains("You are a general purpose multiprovider LLM agent."));
+        assert!(content.contains("The user has given you the following identity:"));
+        assert!(content.contains("I am a helpful agent."));
+        assert!(!content.contains("skills"));
+    }
+
+    #[test]
+    fn skill_alone_produces_structured_message() {
+        let mut builder = PromptBuilder::new();
+        builder.add_skill("rust", "Write idiomatic Rust.");
+        let result = builder.build(&[Message::user("hi".into())]);
+
+        assert_eq!(result.len(), 2);
+        let content = result[0].content.as_deref().unwrap();
+        assert!(content.contains("You are a general purpose multiprovider LLM agent."));
+        assert!(content.contains("These are the skills you have mastered:"));
+        assert!(content.contains("### rust"));
+        assert!(content.contains("Write idiomatic Rust."));
+        assert!(!content.contains("identity"));
+    }
+
+    #[test]
+    fn identity_and_skills_are_both_present_in_order() {
+        let mut builder = PromptBuilder::new();
+        builder.set_system("Custom identity.".into());
+        builder.add_skill("rust", "Be idiomatic.");
+        builder.add_skill("testing", "Write tests.");
+        let result = builder.build(&[Message::user("go".into())]);
+
+        assert_eq!(result.len(), 2);
+        let content = result[0].content.as_deref().unwrap();
+
+        let base_pos = content.find("general purpose").unwrap();
+        let identity_pos = content.find("Custom identity.").unwrap();
+        let skills_pos = content.find("skills you have mastered").unwrap();
+        let rust_pos = content.find("### rust").unwrap();
+        let testing_pos = content.find("### testing").unwrap();
+
+        assert!(base_pos < identity_pos);
+        assert!(identity_pos < skills_pos);
+        assert!(skills_pos < rust_pos);
+        assert!(rust_pos < testing_pos);
+    }
+
+    #[test]
+    fn multiple_skills_are_separated() {
+        let mut builder = PromptBuilder::new();
+        builder.add_skill("a", "Content A");
+        builder.add_skill("b", "Content B");
+        let content = builder.build(&[]).remove(0).content.unwrap();
+        assert!(content.contains("### a"));
+        assert!(content.contains("### b"));
         assert!(content.contains("---"));
     }
 
@@ -107,7 +202,7 @@ mod tests {
         ];
         let result = builder.build(&history);
 
-        assert_eq!(result.len(), 4); // system + 3 history
+        assert_eq!(result.len(), 4);
         assert_eq!(result[0].role, Role::System);
         assert_eq!(result[1].content.as_deref(), Some("first"));
         assert_eq!(result[2].content.as_deref(), Some("second"));

--- a/src/rag/system.rs
+++ b/src/rag/system.rs
@@ -1,0 +1,34 @@
+use crate::config::config_dir;
+use crate::error::{Error, Result};
+use std::path::PathBuf;
+
+/// Loads the system identity from `~/.openheim/system.md`.
+///
+/// The file must exist — run `openheim init` to create it. Returns an error
+/// if the file is absent, mirroring the behaviour of a missing `config.toml`.
+#[derive(Clone)]
+pub struct SystemLoader {
+    path: PathBuf,
+}
+
+impl SystemLoader {
+    /// Creates a `SystemLoader` pointed at `~/.openheim/system.md`.
+    pub fn new() -> Result<Self> {
+        Ok(Self {
+            path: config_dir()?.join("system.md"),
+        })
+    }
+
+    /// Returns the contents of `system.md`.
+    ///
+    /// Returns an error if the file does not exist.
+    pub fn load(&self) -> Result<String> {
+        if !self.path.exists() {
+            return Err(Error::config(format!(
+                "system.md not found at {}. Run `openheim init` to create one.",
+                self.path.display()
+            )));
+        }
+        Ok(std::fs::read_to_string(&self.path)?)
+    }
+}

--- a/src/transport/run.rs
+++ b/src/transport/run.rs
@@ -30,7 +30,7 @@ use crate::{
 pub async fn run_headless(prompt: String, model: Option<String>) -> crate::error::Result<()> {
     let app_config = load_config()?;
     let agent_config = app_config.resolve(model.as_deref())?;
-    let rag = RagContext::new()?;
+    let rag = RagContext::new(app_config.default_skills.clone())?;
     let state = Arc::new(AgentState::new(agent_config, app_config, rag).await?);
 
     let (server_half, client_half) = tokio::io::duplex(65536);
@@ -82,8 +82,6 @@ pub async fn run_headless(prompt: String, model: Option<String>) -> crate::error
         .await
         .map_err(|e| crate::error::Error::Other(e.to_string()))?;
 
-    server_handle
-        .await
-        .map_err(|e| crate::error::Error::Other(e.to_string()))
-        .and_then(|r| r.map_err(|e| crate::error::Error::Other(e.to_string())))
+    server_handle.abort();
+    Ok(())
 }

--- a/src/transport/stdio.rs
+++ b/src/transport/stdio.rs
@@ -21,7 +21,7 @@ use crate::{
 pub async fn run() -> crate::error::Result<()> {
     let app_config = load_config()?;
     let agent_config = app_config.resolve(None)?;
-    let rag = RagContext::new()?;
+    let rag = RagContext::new(app_config.default_skills.clone())?;
     let state = Arc::new(AgentState::new(agent_config, app_config, rag).await?);
 
     acp::serve(Stdio::new(), state)

--- a/src/transport/ws.rs
+++ b/src/transport/ws.rs
@@ -76,7 +76,7 @@ enum WsOutbound {
 pub async fn serve(host: String, port: u16) -> crate::error::Result<()> {
     let app_config = load_config()?;
     let agent_config = app_config.resolve(None)?;
-    let rag = RagContext::new()?;
+    let rag = RagContext::new(app_config.default_skills.clone())?;
     let state = Arc::new(AgentState::new(agent_config, app_config, rag).await?);
 
     let cors = CorsLayer::new()

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -449,17 +449,19 @@ impl App {
                  ↑/↓  scroll · PgUp/PgDn  page · Ctrl+C  quit"
                     .to_string(),
             )),
-            "sessions" => match RagContext::new().and_then(|r| r.history.list_conversations()) {
-                Ok(metas) if metas.is_empty() => {
-                    self.push(ChatItem::SystemInfo("no sessions yet".to_string()));
+            "sessions" => {
+                match RagContext::new(vec![]).and_then(|r| r.history.list_conversations()) {
+                    Ok(metas) if metas.is_empty() => {
+                        self.push(ChatItem::SystemInfo("no sessions yet".to_string()));
+                    }
+                    Ok(metas) => {
+                        self.sessions = metas;
+                        self.picker_selected = 0;
+                        self.push_screen(Screen::SessionPicker);
+                    }
+                    Err(e) => self.push(ChatItem::Err(e.to_string())),
                 }
-                Ok(metas) => {
-                    self.sessions = metas;
-                    self.picker_selected = 0;
-                    self.push_screen(Screen::SessionPicker);
-                }
-                Err(e) => self.push(ChatItem::Err(e.to_string())),
-            },
+            }
             "config" => {
                 let ac = &self.agent_config;
                 let mut rows = vec![
@@ -624,7 +626,7 @@ impl App {
         let title = meta.title.as_deref().unwrap_or("(untitled)");
         self.push(ChatItem::SystemInfo(format!("─── {title}")));
 
-        match RagContext::new().and_then(|r| r.history.load_conversation(&meta.id)) {
+        match RagContext::new(vec![]).and_then(|r| r.history.load_conversation(&meta.id)) {
             Ok(conv) => {
                 for msg in &conv.messages {
                     match msg.role {


### PR DESCRIPTION
## Summary by CodeRabbit

* **New Features**
  * Dedicated agent system identity file and `openheim init` now generates a system identity template
  * New `default_skills` setting to auto-load skills each session

* **Behavior Changes**
  * System identity is required and always loaded first; default and session skills are merged with order preserved and duplicates removed

* **Documentation**
  * Quickstart, guides, and CLI examples updated to the new identity+skills flow and `openheim` subcommands (run, serve, acp, init)