### PR TITLE
Subagents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- **Subagents** — drop a Markdown profile in `~/.openheim/agents/{name}.md` (optional `+++`-delimited TOML frontmatter for `description`, `model`, `provider`, `tools`, `max_iterations`, mirroring how skills work) and the agent gains a `delegate_task` tool for handing off self-contained work to it. Each delegation runs an isolated agent loop — its own message history, persona, and optionally its own model/provider and restricted tool set — sandboxed identically to the parent, and returns only the subagent's final answer. See `docs/subagents.md`.
+
 ## [0.3.0] - 2026-06-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 - **Subagents** — drop a Markdown profile in `~/.openheim/agents/{name}.md` (optional `+++`-delimited TOML frontmatter for `description`, `model`, `provider`, `tools`, `max_iterations`, mirroring how skills work) and the agent gains a `delegate_task` tool for handing off self-contained work to it. Each delegation runs an isolated agent loop — its own message history, persona, and optionally its own model/provider and restricted tool set — sandboxed identically to the parent, and returns only the subagent's final answer. See `docs/subagents.md`.
 
+### Fixed
+
+- **Streaming requests are now retried** — `RetryClient` previously only retried non-streaming `send` calls, so the interactive (streaming) path got no retry on transient failures. Streaming calls are now retried with the same exponential backoff, but only while it is still safe — before the first chunk reaches the caller. Once tokens have been forwarded, a mid-stream failure is returned as-is rather than replayed.
+
+### Breaking changes (library)
+
+- Removed `config::resolve_client_and_config` (unused outside its own tests). Its "reuse the client unless the provider/model changed" logic is now exposed as `config::client_for_config(target, baseline, baseline_llm)`.
+
 ## [0.3.0] - 2026-06-01
 
 ### Added

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -11,6 +11,7 @@
 
 - [Library Usage](library.md)
 - [Skills](skills.md)
+- [Subagents](subagents.md)
 - [Deployment](deployment.md)
 
 ---

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,11 +50,17 @@ src/
 │   ├── system.rs       SystemLoader — reads ~/.openheim/system.md
 │   └── prompt.rs       PromptBuilder — assembles structured system message
 │
+├── subagents/          Subagent profiles — delegated, isolated agent personas
+│   └── mod.rs          AgentProfile, SubagentLoader — Markdown files in ~/.openheim/agents/
+│
 ├── tools/              Tool abstraction and built-in implementations
 │   ├── mod.rs          ToolHandler / ToolExecutor traits, SystemToolExecutor
 │   ├── execute_command.rs
 │   ├── read_file.rs
-│   └── write_file.rs
+│   ├── write_file.rs
+│   ├── sandboxed_executor.rs  SandboxedExecutor — work_dir / allow_shell boundary
+│   ├── scoped_executor.rs     ScopedExecutor — tool-name allowlist wrapper
+│   └── delegate.rs            DelegateTool, with_delegation — delegate_task tool
 │
 ├── mcp/                Model Context Protocol client
 │   ├── mod.rs          load_mcp_tools(), McpServerStatus

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,6 +37,7 @@ src/
 │   │   ├── openai.rs
 │   │   ├── gemini.rs
 │   │   ├── openai_compatible.rs
+│   │   ├── sse.rs      Shared Server-Sent Events decoder for streaming
 │   │   └── retry.rs    Exponential-backoff wrapper
 │   └── models.rs       Shared data types (Message, Tool, Choice, …)
 │

--- a/docs/custom-llm-provider.md
+++ b/docs/custom-llm-provider.md
@@ -200,7 +200,7 @@ impl LlmClient for MyCustomProvider {
 
 ### 4. Wrap with `RetryClient` (optional but recommended)
 
-`RetryClient` wraps any `LlmClient` and retries on transient errors (rate limits, 5xx, network timeouts) with exponential backoff:
+`RetryClient` wraps any `LlmClient` and retries on transient errors (rate limits, 5xx, network timeouts) with exponential backoff. Non-streaming `send` calls are retried up to three times; streaming `send_streaming` calls are retried only while it is still safe — i.e. before your provider has emitted the first chunk to the caller. Once the first token has been forwarded, a mid-stream failure is returned as-is rather than replayed (which would duplicate output):
 
 ```rust
 use openheim::llm::RetryClient;

--- a/docs/subagents.md
+++ b/docs/subagents.md
@@ -1,0 +1,118 @@
+# Subagents
+
+Subagents let the agent delegate a self-contained task to another, independently
+configured agent — its own persona, its own model/provider, optionally its own
+restricted tool set — and get back only the final answer. They're useful for
+splitting work across specialised personas (a reviewer, a researcher, a
+fact-checker, …) or for routing routine subtasks to a cheaper/faster model while
+the orchestrator runs on a stronger one.
+
+This mirrors how [skills](skills.md) work — drop a Markdown file in a directory and
+it's picked up automatically — except a subagent profile defines a *whole separate
+agent* rather than a snippet appended to the current one.
+
+---
+
+## Where subagent profiles live
+
+Profiles are `.md` files in `~/.openheim/agents/`:
+
+```
+~/.openheim/agents/
+├── code-reviewer.md
+├── researcher.md
+└── fact-checker.md
+```
+
+The filename (without extension) is the subagent's name. Names are case-sensitive
+and must not contain spaces.
+
+If the directory contains at least one valid profile, the orchestrating agent gains
+a `delegate_task` tool whose description lists every available subagent by name and
+description, so the LLM knows what's available and when to reach for it. If the
+directory is empty, `delegate_task` is not added — there's no overhead for agents
+that don't use subagents.
+
+---
+
+## Writing a profile
+
+A profile file is Markdown with an optional `+++`-delimited TOML frontmatter block,
+followed by the subagent's system prompt:
+
+```markdown
++++
+description = "Reviews code changes for correctness, security, and style. Use for a second opinion on a diff."
+model = "claude-haiku-4-5"
+provider = "anthropic"
+tools = ["read_file"]
+max_iterations = 6
++++
+You are a meticulous code reviewer focused on correctness, security, and idiomatic style.
+Always cite file:line references for issues you find.
+```
+
+All frontmatter fields are optional:
+
+| Field | Type | Effect |
+|---|---|---|
+| `description` | string | Shown to the orchestrator so it knows when to delegate to this subagent. Omitting it is allowed but makes the subagent harder for the LLM to discover. |
+| `model` | string | Overrides the parent's model for this subagent's run. |
+| `provider` | string | Overrides the parent's provider. Only used when `model` is also set. |
+| `tools` | array of strings | Restricts the subagent to this set of tool names. Omitted = inherits the full tool set the parent has access to. |
+| `max_iterations` | integer | Caps the subagent's agent-loop iterations. Omitted = inherits the parent's `max_iterations`. |
+
+A file with no frontmatter is treated as a profile with an empty description whose
+entire contents are the system prompt. A profile whose frontmatter fails to parse is
+skipped (with a warning logged) rather than preventing startup.
+
+---
+
+## How a delegated task runs
+
+When the orchestrator calls `delegate_task` with an `agent` name and a `task`
+description, openheim:
+
+1. Resolves the subagent's model/provider/iteration cap from the profile (falling
+   back to the parent's configuration for anything left unset).
+2. Builds a tool executor scoped to the profile's `tools` allowlist (if any) and
+   wrapped in the **same sandbox boundary** (`work_dir` / `allow_shell`) as the
+   parent — subagents cannot escalate privileges beyond what the parent has.
+3. Starts a **fresh, isolated** agent run: its own message history (just the `task`
+   as the first user message) and its own system prompt (the profile's persona —
+   not the parent's `system.md` or skills).
+4. Runs that agent loop to completion and returns only its final answer to the
+   orchestrator. Intermediate tool calls and reasoning are not visible to the
+   parent — the subagent genuinely runs "in the background", much like Claude
+   Code's `Task` subagents.
+
+Because the subagent is built from a tool executor that does not include
+`delegate_task` itself, subagents cannot delegate further — there is no recursive
+chain to worry about.
+
+> **Tip:** since the subagent cannot see the parent conversation, write `task`
+> descriptions in the calling prompt (or trust the orchestrator to write them) as
+> complete, self-contained briefs. The LLM is told this in the tool description, but
+> it helps to reinforce it in your `system.md` or skills if you rely on subagents
+> heavily.
+
+---
+
+## Example
+
+`~/.openheim/agents/fact-checker.md`:
+
+```markdown
++++
+description = "Verifies a specific factual claim and reports whether it's accurate, with sources if possible."
+max_iterations = 4
++++
+You are a fact-checker. Given a claim, determine whether it is accurate.
+Respond with a verdict (Accurate / Inaccurate / Uncertain) followed by a one-paragraph explanation.
+Be concise — you have a limited number of steps to reach a conclusion.
+```
+
+With this file in place, asking the orchestrator something like "use the
+fact-checker subagent to verify that water boils at 100°C at sea level" causes it to
+call `delegate_task` with `{"agent": "fact-checker", "task": "Verify the claim: water boils at 100°C at sea level."}`
+and relay the fact-checker's verdict back to you.

--- a/src/acp/mod.rs
+++ b/src/acp/mod.rs
@@ -31,7 +31,8 @@ use crate::{
     error::{Error, Result},
     llm::LlmClient,
     rag::RagContext,
-    tools::{SandboxedExecutor, SystemToolExecutor, ToolExecutor},
+    subagents::SubagentLoader,
+    tools::{SandboxedExecutor, SystemToolExecutor, ToolExecutor, with_delegation},
 };
 
 use session::SessionState;
@@ -57,9 +58,6 @@ impl AgentState {
         let http_client = build_http_client(config.timeout_secs)?;
         let llm = create_client(&config, &http_client);
         let allow_shell = app_config.allow_shell;
-        let (sys_executor, mcp_statuses) =
-            SystemToolExecutor::build(&app_config.mcp_servers, allow_shell).await;
-        let executor = Arc::new(sys_executor) as Arc<dyn ToolExecutor>;
         let work_dir = match app_config.work_dir.clone() {
             Some(wd) => wd,
             None => std::env::current_dir().map_err(|e| {
@@ -68,6 +66,21 @@ impl AgentState {
                 ))
             })?,
         };
+        let (sys_executor, mcp_statuses) =
+            SystemToolExecutor::build(&app_config.mcp_servers, allow_shell).await;
+        let executor = Arc::new(sys_executor) as Arc<dyn ToolExecutor>;
+
+        let profiles = SubagentLoader::new()?.load()?;
+        let executor = with_delegation(
+            executor,
+            work_dir.clone(),
+            allow_shell,
+            profiles,
+            llm.clone(),
+            app_config.clone(),
+            config.clone(),
+        );
+
         Ok(Self {
             llm,
             executor,

--- a/src/acp/mod.rs
+++ b/src/acp/mod.rs
@@ -117,13 +117,13 @@ impl AgentState {
         Ok(session_key)
     }
 
-    pub async fn acp_update_session_model(
+    /// Swaps a live session's [`AgentConfig`], returning its `(provider, model)`.
+    /// Shared by the two public model-switch entry points below.
+    async fn apply_session_config(
         &self,
         session_id: &str,
-        provider: &str,
-        model: &str,
+        new_config: AgentConfig,
     ) -> Result<(String, String)> {
-        let new_config = self.app_config.resolve_with_provider(provider, model)?;
         let provider_name = new_config.provider_name.clone();
         let model_name = new_config.model.clone();
         let mut sessions = self.sessions.write().await;
@@ -134,20 +134,23 @@ impl AgentState {
         Ok((provider_name, model_name))
     }
 
+    pub async fn acp_update_session_model(
+        &self,
+        session_id: &str,
+        provider: &str,
+        model: &str,
+    ) -> Result<(String, String)> {
+        let new_config = self.app_config.resolve_with_provider(provider, model)?;
+        self.apply_session_config(session_id, new_config).await
+    }
+
     pub async fn acp_set_session_model(
         &self,
         session_id: &str,
         model_id: &str,
     ) -> Result<(String, String)> {
         let new_config = self.app_config.resolve(Some(model_id))?;
-        let provider_name = new_config.provider_name.clone();
-        let model_name = new_config.model.clone();
-        let mut sessions = self.sessions.write().await;
-        let s = sessions
-            .get_mut(session_id)
-            .ok_or_else(|| Error::Other(format!("session not found: {session_id}")))?;
-        s.config = new_config;
-        Ok((provider_name, model_name))
+        self.apply_session_config(session_id, new_config).await
     }
 
     pub fn session_model_state(&self, current_model: &str) -> SessionModelState {
@@ -183,14 +186,7 @@ impl AgentState {
             let s = sessions
                 .get(session_id)
                 .ok_or_else(|| Error::Other(format!("session not found: {session_id}")))?;
-            let llm = if s.config.provider_name != self.config.provider_name
-                || s.config.model != self.config.model
-            {
-                let http_client = crate::config::build_http_client(s.config.timeout_secs)?;
-                crate::config::create_client(&s.config, &http_client)
-            } else {
-                self.llm.clone()
-            };
+            let llm = crate::config::client_for_config(&s.config, &self.config, &self.llm)?;
             let sandboxed = Arc::new(SandboxedExecutor::new(
                 self.executor.clone(),
                 self.work_dir.clone(),

--- a/src/config/client.rs
+++ b/src/config/client.rs
@@ -2,7 +2,7 @@ use reqwest::Client as ReqwestClient;
 use std::sync::Arc;
 use std::time::Duration;
 
-use super::types::{AgentConfig, AppConfig};
+use super::types::AgentConfig;
 use crate::core::llm::{
     AnthropicClient, GeminiClient, LlmClient, OpenAiClient, OpenAiCompatibleClient, RetryClient,
 };
@@ -51,42 +51,33 @@ pub fn create_client(config: &AgentConfig, http_client: &ReqwestClient) -> Arc<d
     Arc::new(RetryClient::new(inner))
 }
 
-/// Resolves the LLM client and agent configuration based on an optional model name and max iterations.
+/// Returns the LLM client to use for `target`, reusing `baseline_llm` when it
+/// already points at the same provider and model, and otherwise building a fresh
+/// client for `target`.
 ///
-/// If `model_name` is provided, resolves against the `AppConfig` to determine the correct provider.
-/// Otherwise, uses the provided `default_llm` and `default_config`.
-pub fn resolve_client_and_config(
-    model_name: Option<&str>,
-    max_iterations: Option<usize>,
-    app_config: &AppConfig,
-    default_llm: Arc<dyn LlmClient>,
-    default_config: &AgentConfig,
-) -> Result<(Arc<dyn LlmClient>, AgentConfig)> {
-    if let Some(model) = model_name {
-        let mut resolved = app_config.resolve(Some(model))?;
-        if let Some(max_iter) = max_iterations {
-            resolved.max_iterations = max_iter;
-        }
-        let resolved_http = build_http_client(resolved.timeout_secs)?;
-        let client = create_client(&resolved, &resolved_http);
-        Ok((client, resolved))
+/// This is the single source of truth for the "reuse the parent client unless
+/// the model/provider changed" pattern needed when a session switches models
+/// (`acp_prompt`) or a subagent runs under a different model
+/// (`DelegateTool::resolve_runtime`).
+pub fn client_for_config(
+    target: &AgentConfig,
+    baseline: &AgentConfig,
+    baseline_llm: &Arc<dyn LlmClient>,
+) -> Result<Arc<dyn LlmClient>> {
+    if target.provider_name == baseline.provider_name && target.model == baseline.model {
+        Ok(baseline_llm.clone())
     } else {
-        let mut cfg = default_config.clone();
-        if let Some(max_iter) = max_iterations {
-            cfg.max_iterations = max_iter;
-        }
-        Ok((default_llm, cfg))
+        let http_client = build_http_client(target.timeout_secs)?;
+        Ok(create_client(target, &http_client))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::ProviderConfig;
     use crate::core::llm::LlmClient;
     use crate::core::models::{Choice, Message, Tool};
     use async_trait::async_trait;
-    use std::collections::BTreeMap;
 
     struct DummyClient;
 
@@ -101,124 +92,55 @@ mod tests {
         }
     }
 
-    fn sample_app_config() -> AppConfig {
-        let mut providers = BTreeMap::new();
-        providers.insert(
-            "openai".into(),
-            ProviderConfig {
-                api_base: "https://api.openai.com/v1".into(),
-                default_model: "gpt-4".into(),
-                models: vec!["gpt-4".into()],
-                env_var: None,
-                api_key: Some("key".into()),
-                timeout_secs: Some(30),
-                max_tokens: None,
-            },
-        );
-        AppConfig {
-            default_provider: "openai".into(),
-            max_iterations: 10,
-            theme_color: None,
-            providers,
-            mcp_servers: BTreeMap::new(),
-            default_skills: vec![],
-            work_dir: None,
-            allow_shell: true,
-        }
-    }
-
-    #[test]
-    fn resolve_client_uses_default_when_no_model() {
-        let app_config = sample_app_config();
-        let default_llm: Arc<dyn LlmClient> = Arc::new(DummyClient);
-        let default_config = AgentConfig::new(
+    fn baseline_config() -> AgentConfig {
+        AgentConfig::new(
             "openai".into(),
             "https://api.openai.com/v1".into(),
             "key".into(),
             "gpt-4".into(),
             10,
-        );
-
-        let (client, cfg) = resolve_client_and_config(
-            None,
-            None,
-            &app_config,
-            default_llm.clone(),
-            &default_config,
         )
-        .unwrap();
-
-        assert!(Arc::ptr_eq(&client, &default_llm));
-        assert_eq!(cfg.max_iterations, 10);
     }
 
     #[test]
-    fn resolve_client_overrides_max_iterations() {
-        let app_config = sample_app_config();
-        let default_llm: Arc<dyn LlmClient> = Arc::new(DummyClient);
-        let default_config = AgentConfig::new(
-            "openai".into(),
-            "https://api.openai.com/v1".into(),
+    fn client_for_config_reuses_baseline_when_provider_and_model_match() {
+        let baseline = baseline_config();
+        let baseline_llm: Arc<dyn LlmClient> = Arc::new(DummyClient);
+
+        // Same provider + model, even with a different api_base/timeout.
+        let mut target = baseline.clone();
+        target.timeout_secs = 999;
+
+        let client = client_for_config(&target, &baseline, &baseline_llm).unwrap();
+        assert!(Arc::ptr_eq(&client, &baseline_llm));
+    }
+
+    #[test]
+    fn client_for_config_builds_new_when_model_differs() {
+        let baseline = baseline_config();
+        let baseline_llm: Arc<dyn LlmClient> = Arc::new(DummyClient);
+
+        let mut target = baseline.clone();
+        target.model = "gpt-4o".into();
+
+        let client = client_for_config(&target, &baseline, &baseline_llm).unwrap();
+        assert!(!Arc::ptr_eq(&client, &baseline_llm));
+    }
+
+    #[test]
+    fn client_for_config_builds_new_when_provider_differs() {
+        let baseline = baseline_config();
+        let baseline_llm: Arc<dyn LlmClient> = Arc::new(DummyClient);
+
+        let target = AgentConfig::new(
+            "anthropic".into(),
+            "https://api.anthropic.com/v1".into(),
             "key".into(),
             "gpt-4".into(),
             10,
         );
 
-        let (_client, cfg) =
-            resolve_client_and_config(None, Some(25), &app_config, default_llm, &default_config)
-                .unwrap();
-
-        assert_eq!(cfg.max_iterations, 25);
-    }
-
-    #[test]
-    fn resolve_client_creates_new_for_specific_model() {
-        let app_config = sample_app_config();
-        let default_llm: Arc<dyn LlmClient> = Arc::new(DummyClient);
-        let default_config = AgentConfig::new(
-            "openai".into(),
-            "https://api.openai.com/v1".into(),
-            "key".into(),
-            "gpt-4".into(),
-            10,
-        );
-
-        let (client, cfg) = resolve_client_and_config(
-            Some("gpt-4"),
-            Some(3),
-            &app_config,
-            default_llm.clone(),
-            &default_config,
-        )
-        .unwrap();
-
-        // New client is created, not the default one
-        assert!(!Arc::ptr_eq(&client, &default_llm));
-        assert_eq!(cfg.model, "gpt-4");
-        assert_eq!(cfg.max_iterations, 3);
-    }
-
-    #[test]
-    fn resolve_client_errors_for_unknown_model() {
-        let app_config = sample_app_config();
-        let default_llm: Arc<dyn LlmClient> = Arc::new(DummyClient);
-        let default_config = AgentConfig::default();
-
-        let result = resolve_client_and_config(
-            Some("nonexistent-model"),
-            None,
-            &app_config,
-            default_llm,
-            &default_config,
-        );
-
-        assert!(result.is_err());
-        assert!(
-            result
-                .err()
-                .unwrap()
-                .to_string()
-                .contains("nonexistent-model")
-        );
+        let client = client_for_config(&target, &baseline, &baseline_llm).unwrap();
+        assert!(!Arc::ptr_eq(&client, &baseline_llm));
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -2,7 +2,7 @@ mod client;
 mod resolve;
 mod types;
 
-pub use client::{build_http_client, create_client, resolve_client_and_config};
+pub use client::{build_http_client, client_for_config, create_client};
 pub use types::{
     AgentConfig, AppConfig, McpServerConfig, ModelsInfo, ProviderConfig, ProviderModels,
 };

--- a/src/core/llm/anthropic.rs
+++ b/src/core/llm/anthropic.rs
@@ -7,6 +7,7 @@ use tokio::sync::mpsc;
 use crate::core::models::{Choice, FunctionCall, Message, Role, Tool, ToolCall};
 use crate::error::{Error, Result};
 
+use super::sse::SseDecoder;
 use super::{LlmChunk, LlmClient};
 
 const ANTHROPIC_VERSION: &str = "2023-06-01";
@@ -381,7 +382,7 @@ impl LlmClient for AnthropicClient {
         }
 
         // Parse SSE stream.
-        let mut buf = String::new();
+        let mut decoder = SseDecoder::new();
         let mut current_block_type: Option<String> = None;
         let mut current_tool_id: Option<String> = None;
         let mut current_tool_name: Option<String> = None;
@@ -392,22 +393,14 @@ impl LlmClient for AnthropicClient {
 
         let mut response = response;
         while let Some(chunk) = response.chunk().await.map_err(Error::ReqwestError)? {
-            buf.push_str(&String::from_utf8_lossy(&chunk));
+            decoder.feed(&chunk);
 
-            while let Some(nl_pos) = buf.find('\n') {
-                let line = buf[..nl_pos].trim_end_matches('\r').to_string();
-                buf.drain(..=nl_pos);
-
-                let data = match line.strip_prefix("data: ") {
-                    Some(d) => d.trim(),
-                    None => continue,
-                };
-
+            while let Some(data) = decoder.next_payload() {
                 if data == "[DONE]" || data.is_empty() {
                     continue;
                 }
 
-                let event: Value = match serde_json::from_str(data) {
+                let event: Value = match serde_json::from_str(&data) {
                     Ok(v) => v,
                     Err(_) => continue,
                 };

--- a/src/core/llm/gemini.rs
+++ b/src/core/llm/gemini.rs
@@ -7,6 +7,7 @@ use tokio::sync::mpsc;
 use crate::core::models::{Choice, FunctionCall, Message, Role, Tool, ToolCall};
 use crate::error::{Error, Result};
 
+use super::sse::SseDecoder;
 use super::{LlmChunk, LlmClient};
 
 #[derive(Clone)]
@@ -388,26 +389,13 @@ impl LlmClient for GeminiClient {
         let mut text_buf = String::new();
         let mut tool_calls: Vec<ToolCall> = Vec::new();
         let mut finish_reason: Option<String> = None;
-        let mut line_buf = String::new();
+        let mut decoder = SseDecoder::new();
 
         while let Some(bytes) = response.chunk().await.map_err(Error::ReqwestError)? {
-            line_buf.push_str(&String::from_utf8_lossy(&bytes));
+            decoder.feed(&bytes);
 
-            loop {
-                let Some(pos) = line_buf.find('\n') else {
-                    break;
-                };
-                let line = line_buf[..pos].trim_end_matches('\r').to_string();
-                line_buf.drain(..=pos);
-
-                if line.is_empty() || line.starts_with(':') {
-                    continue;
-                }
-                let Some(data) = line.strip_prefix("data: ") else {
-                    continue;
-                };
-
-                let Ok(event) = serde_json::from_str::<GeminiResponse>(data) else {
+            while let Some(data) = decoder.next_payload() {
+                let Ok(event) = serde_json::from_str::<GeminiResponse>(&data) else {
                     continue;
                 };
 

--- a/src/core/llm/mod.rs
+++ b/src/core/llm/mod.rs
@@ -3,6 +3,7 @@ mod gemini;
 mod openai;
 mod openai_compatible;
 mod retry;
+mod sse;
 
 use async_trait::async_trait;
 use tokio::sync::mpsc;

--- a/src/core/llm/openai.rs
+++ b/src/core/llm/openai.rs
@@ -7,6 +7,7 @@ use crate::core::models::{
 };
 use crate::error::{Error, Result};
 
+use super::sse::SseDecoder;
 use super::{LlmChunk, LlmClient};
 
 #[derive(Clone)]
@@ -131,35 +132,22 @@ pub(super) async fn send_openai_style_streaming(
     let mut text_buf = String::new();
     let mut tool_acc: Vec<ToolCallAcc> = Vec::new();
     let mut finish_reason: Option<String> = None;
-    let mut line_buf = String::new();
+    let mut decoder = SseDecoder::new();
     let mut done = false;
 
     while !done {
         let Some(bytes) = response.chunk().await.map_err(Error::ReqwestError)? else {
             break;
         };
-        line_buf.push_str(&String::from_utf8_lossy(&bytes));
+        decoder.feed(&bytes);
 
-        loop {
-            let Some(pos) = line_buf.find('\n') else {
-                break;
-            };
-            let line = line_buf[..pos].trim_end_matches('\r').to_string();
-            line_buf.drain(..=pos);
-
-            if line.is_empty() || line.starts_with(':') {
-                continue;
-            }
-            let Some(data) = line.strip_prefix("data: ") else {
-                continue;
-            };
-
+        while let Some(data) = decoder.next_payload() {
             if data == "[DONE]" {
                 done = true;
                 break;
             }
 
-            let Ok(event) = serde_json::from_str::<serde_json::Value>(data) else {
+            let Ok(event) = serde_json::from_str::<serde_json::Value>(&data) else {
                 continue;
             };
 

--- a/src/core/llm/retry.rs
+++ b/src/core/llm/retry.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -46,13 +47,60 @@ impl LlmClient for RetryClient {
         unreachable!("loop always returns via Ok or Err arm")
     }
 
+    /// Retries a failed streaming request **only while it is still safe to do
+    /// so** — i.e. before any chunk has reached the caller. Once the first token
+    /// has been forwarded a mid-stream failure can't be replayed without
+    /// duplicating output, so it is returned as-is.
+    ///
+    /// Each attempt streams through a private channel; a forwarder relays chunks
+    /// to the caller's `chunk_tx` and records whether anything was emitted.
     async fn send_streaming(
         &self,
         messages: &[Message],
         tools: &[Tool],
         chunk_tx: mpsc::UnboundedSender<LlmChunk>,
     ) -> Result<Choice> {
-        self.inner.send_streaming(messages, tools, chunk_tx).await
+        for attempt in 0..=MAX_RETRIES {
+            let (inner_tx, mut inner_rx) = mpsc::unbounded_channel::<LlmChunk>();
+            let emitted = Arc::new(AtomicBool::new(false));
+
+            let forward_tx = chunk_tx.clone();
+            let forward_emitted = emitted.clone();
+            let forwarder = tokio::spawn(async move {
+                while let Some(chunk) = inner_rx.recv().await {
+                    forward_emitted.store(true, Ordering::SeqCst);
+                    if forward_tx.send(chunk).is_err() {
+                        break;
+                    }
+                }
+            });
+
+            let result = self.inner.send_streaming(messages, tools, inner_tx).await;
+            // `inner_tx` is dropped when the call returns, so the forwarder drains
+            // any remaining buffered chunks and then exits.
+            let _ = forwarder.await;
+
+            match result {
+                Ok(choice) => return Ok(choice),
+                Err(e)
+                    if attempt < MAX_RETRIES
+                        && e.is_retryable()
+                        && !emitted.load(Ordering::SeqCst) =>
+                {
+                    let backoff = Duration::from_millis(INITIAL_BACKOFF_MS * 2u64.pow(attempt));
+                    tracing::warn!(
+                        "LLM stream failed before first chunk (attempt {}/{}): {}. Retrying in {:?}...",
+                        attempt + 1,
+                        MAX_RETRIES + 1,
+                        e,
+                        backoff
+                    );
+                    sleep(backoff).await;
+                }
+                Err(e) => return Err(e),
+            }
+        }
+        unreachable!("loop always returns via Ok or Err arm")
     }
 }
 
@@ -195,5 +243,97 @@ mod tests {
         assert!(result.is_err());
         // Should have been called 1 (initial) + 3 (retries) = 4 times
         assert_eq!(inner.call_count.load(Ordering::SeqCst), 4);
+    }
+
+    /// Streaming mock that fails (without emitting) the first `failures` times,
+    /// then succeeds. Records how many times `send_streaming` was entered.
+    struct StreamFailThenSucceed {
+        remaining_failures: AtomicUsize,
+        calls: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl LlmClient for StreamFailThenSucceed {
+        async fn send(&self, _messages: &[Message], _tools: &[Tool]) -> Result<Choice> {
+            unimplemented!("streaming test only uses send_streaming")
+        }
+
+        async fn send_streaming(
+            &self,
+            _messages: &[Message],
+            _tools: &[Tool],
+            chunk_tx: mpsc::UnboundedSender<LlmChunk>,
+        ) -> Result<Choice> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            if self.remaining_failures.fetch_sub(1, Ordering::SeqCst) > 0 {
+                // Fail before emitting anything — safe to retry.
+                Err(Error::HttpError {
+                    status: 503,
+                    body: "service unavailable".into(),
+                })
+            } else {
+                let _ = chunk_tx.send(LlmChunk::Text("hello".into()));
+                Ok(ok_choice("hello"))
+            }
+        }
+    }
+
+    /// Streaming mock that emits a chunk and *then* fails with a retryable error,
+    /// to verify mid-stream failures are not retried.
+    struct StreamEmitThenFail {
+        calls: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl LlmClient for StreamEmitThenFail {
+        async fn send(&self, _messages: &[Message], _tools: &[Tool]) -> Result<Choice> {
+            unimplemented!("streaming test only uses send_streaming")
+        }
+
+        async fn send_streaming(
+            &self,
+            _messages: &[Message],
+            _tools: &[Tool],
+            chunk_tx: mpsc::UnboundedSender<LlmChunk>,
+        ) -> Result<Choice> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            let _ = chunk_tx.send(LlmChunk::Text("partial".into()));
+            Err(Error::HttpError {
+                status: 503,
+                body: "dropped mid-stream".into(),
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn streaming_retries_when_failure_precedes_first_chunk() {
+        let inner = Arc::new(StreamFailThenSucceed {
+            remaining_failures: AtomicUsize::new(2),
+            calls: AtomicUsize::new(0),
+        });
+        let client = RetryClient::new(inner.clone());
+        let (tx, mut rx) = mpsc::unbounded_channel();
+
+        let result = client.send_streaming(&[], &[], tx).await;
+
+        assert!(result.is_ok());
+        assert_eq!(inner.calls.load(Ordering::SeqCst), 3); // 2 failures + 1 success
+        // The caller only sees the chunk from the successful attempt.
+        assert!(matches!(rx.recv().await, Some(LlmChunk::Text(t)) if t == "hello"));
+    }
+
+    #[tokio::test]
+    async fn streaming_does_not_retry_after_a_chunk_was_emitted() {
+        let inner = Arc::new(StreamEmitThenFail {
+            calls: AtomicUsize::new(0),
+        });
+        let client = RetryClient::new(inner.clone());
+        let (tx, _rx) = mpsc::unbounded_channel();
+
+        let result = client.send_streaming(&[], &[], tx).await;
+
+        assert!(result.is_err());
+        // A single attempt: the emitted chunk makes the failure non-retryable.
+        assert_eq!(inner.calls.load(Ordering::SeqCst), 1);
     }
 }

--- a/src/core/llm/sse.rs
+++ b/src/core/llm/sse.rs
@@ -1,0 +1,82 @@
+//! Minimal incremental Server-Sent Events decoder shared by the streaming
+//! provider clients.
+//!
+//! Each provider's streaming endpoint frames its response as SSE: UTF-8 chunks
+//! arrive over the wire, split into `\n`-terminated lines, and the payloads we
+//! care about are carried on `data:` lines. This decoder owns the cross-chunk
+//! line buffering and `data:` extraction so the three providers
+//! ([`super::anthropic`], [`super::gemini`], [`super::openai`]) don't each
+//! re-implement the same framing state machine (and drift apart in the details).
+//!
+//! Interpreting each payload — JSON shape, the `[DONE]` sentinel, etc. — stays
+//! with the caller, since that part genuinely differs per provider.
+
+/// Accumulates raw byte chunks and yields complete SSE `data:` payloads.
+pub(crate) struct SseDecoder {
+    buf: String,
+}
+
+impl SseDecoder {
+    pub(crate) fn new() -> Self {
+        Self { buf: String::new() }
+    }
+
+    /// Appends a raw byte chunk (as received from the HTTP body) to the buffer.
+    pub(crate) fn feed(&mut self, bytes: &[u8]) {
+        self.buf.push_str(&String::from_utf8_lossy(bytes));
+    }
+
+    /// Pops the next complete `data:` payload, or `None` if no full line is
+    /// buffered yet. Blank lines, comment lines (`:` prefix), and non-`data`
+    /// fields (`event:`, `id:`, …) are skipped. The returned payload is trimmed.
+    pub(crate) fn next_payload(&mut self) -> Option<String> {
+        while let Some(nl) = self.buf.find('\n') {
+            let line = self.buf[..nl].trim_end_matches('\r').to_string();
+            self.buf.drain(..=nl);
+
+            if line.is_empty() || line.starts_with(':') {
+                continue;
+            }
+            if let Some(data) = line
+                .strip_prefix("data: ")
+                .or_else(|| line.strip_prefix("data:"))
+            {
+                return Some(data.trim().to_string());
+            }
+            // A non-data field line (event:/id:/retry:) — nothing to surface.
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn yields_payloads_split_across_chunks() {
+        let mut dec = SseDecoder::new();
+        dec.feed(b"data: hel");
+        assert_eq!(dec.next_payload(), None);
+        dec.feed(b"lo\ndata: world\n");
+        assert_eq!(dec.next_payload().as_deref(), Some("hello"));
+        assert_eq!(dec.next_payload().as_deref(), Some("world"));
+        assert_eq!(dec.next_payload(), None);
+    }
+
+    #[test]
+    fn skips_blank_and_comment_lines() {
+        let mut dec = SseDecoder::new();
+        dec.feed(b"\n: keep-alive\nevent: ping\ndata: payload\n");
+        assert_eq!(dec.next_payload().as_deref(), Some("payload"));
+        assert_eq!(dec.next_payload(), None);
+    }
+
+    #[test]
+    fn handles_crlf_and_missing_space_after_colon() {
+        let mut dec = SseDecoder::new();
+        dec.feed(b"data:no-space\r\ndata: [DONE]\r\n");
+        assert_eq!(dec.next_payload().as_deref(), Some("no-space"));
+        assert_eq!(dec.next_payload().as_deref(), Some("[DONE]"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ pub mod core;
 pub mod error;
 pub mod mcp;
 pub mod rag;
+pub mod subagents;
 pub mod tools;
 pub mod transport;
 pub mod tui;

--- a/src/subagents/mod.rs
+++ b/src/subagents/mod.rs
@@ -1,0 +1,220 @@
+//! Subagent profiles: named, user-defined agent personas that the orchestrating
+//! agent can delegate self-contained tasks to via the `delegate_task` tool
+//! (see [`crate::tools::delegate`]).
+//!
+//! A profile is a Markdown file in `~/.openheim/agents/{name}.md`, discovered the
+//! same way [`crate::rag::SkillsManager`] discovers skill files. The file may start
+//! with a `+++`-delimited TOML frontmatter block describing the profile; the rest
+//! of the file is used verbatim as the subagent's system prompt.
+//!
+//! ```markdown
+//! +++
+//! description = "Reviews code changes for correctness, security, and style."
+//! model = "claude-haiku-4-5"
+//! tools = ["read_file"]
+//! max_iterations = 6
+//! +++
+//! You are a meticulous code reviewer focused on correctness and idiomatic style.
+//! ```
+//!
+//! All frontmatter fields are optional. A file with no frontmatter is treated as a
+//! profile with an empty description whose entire contents form the system prompt.
+
+use std::path::PathBuf;
+
+use serde::Deserialize;
+
+use crate::config::config_dir;
+use crate::error::{Error, Result};
+
+/// A user-defined subagent persona loaded from `~/.openheim/agents/{name}.md`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct AgentProfile {
+    /// Derived from the filename (without the `.md` extension).
+    pub name: String,
+    /// One-line summary shown to the orchestrating LLM so it knows when to delegate here.
+    pub description: String,
+    /// Overrides the parent's model when set (paired with `provider`).
+    pub model: Option<String>,
+    /// Overrides the parent's provider when set (paired with `model`).
+    pub provider: Option<String>,
+    /// Restricts the subagent to this set of tool names. `None` inherits the parent's tools.
+    pub tools: Option<Vec<String>>,
+    /// Caps the subagent's agent-loop iterations. `None` inherits the parent's setting.
+    pub max_iterations: Option<usize>,
+    /// The subagent's system prompt — the body of the Markdown file.
+    pub system_prompt: String,
+}
+
+/// Deserialized shape of a profile's `+++` frontmatter block. All fields optional.
+#[derive(Debug, Default, Deserialize)]
+struct AgentProfileMeta {
+    #[serde(default)]
+    description: String,
+    #[serde(default)]
+    model: Option<String>,
+    #[serde(default)]
+    provider: Option<String>,
+    #[serde(default)]
+    tools: Option<Vec<String>>,
+    #[serde(default)]
+    max_iterations: Option<usize>,
+}
+
+/// Discovers and loads [`AgentProfile`]s from `~/.openheim/agents/`.
+///
+/// Mirrors [`crate::rag::SkillsManager`]: a profile is named after its file
+/// (`{name}.md`), and the directory is created on first use if missing.
+#[derive(Clone)]
+pub struct SubagentLoader {
+    agents_dir: PathBuf,
+}
+
+impl SubagentLoader {
+    /// Creates a `SubagentLoader` backed by `~/.openheim/agents/`, creating the
+    /// directory if it doesn't exist.
+    pub fn new() -> Result<Self> {
+        let dir = config_dir()?.join("agents");
+        std::fs::create_dir_all(&dir)?;
+        Ok(Self { agents_dir: dir })
+    }
+
+    /// Loads every valid `.md` profile in the agents directory, sorted by name.
+    ///
+    /// A file whose frontmatter fails to parse is skipped with a warning rather
+    /// than failing the whole load — one malformed profile shouldn't prevent the
+    /// agent from starting.
+    pub fn load(&self) -> Result<Vec<AgentProfile>> {
+        let mut profiles = Vec::new();
+        for entry in std::fs::read_dir(&self.agents_dir)? {
+            let path = entry?.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("md") {
+                continue;
+            }
+            let Some(name) = path.file_stem().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            let content = std::fs::read_to_string(&path)?;
+            match parse_profile(name, &content) {
+                Ok(profile) => profiles.push(profile),
+                Err(e) => tracing::warn!(
+                    file = %path.display(),
+                    error = %e,
+                    "Skipping invalid subagent profile"
+                ),
+            }
+        }
+        profiles.sort_by(|a, b| a.name.cmp(&b.name));
+        Ok(profiles)
+    }
+}
+
+/// Parses a profile file's content into an [`AgentProfile`] named `name`.
+fn parse_profile(name: &str, content: &str) -> Result<AgentProfile> {
+    let (meta, body) = split_frontmatter(content)?;
+    Ok(AgentProfile {
+        name: name.to_string(),
+        description: meta.description,
+        model: meta.model,
+        provider: meta.provider,
+        tools: meta.tools,
+        max_iterations: meta.max_iterations,
+        system_prompt: body.trim().to_string(),
+    })
+}
+
+/// Splits an optional `+++`-delimited TOML frontmatter block from the Markdown body.
+///
+/// Files that don't start with `+++` have no frontmatter: the whole content becomes
+/// the system prompt and the metadata defaults to empty. An opening `+++` with no
+/// matching closing delimiter is a parse error.
+fn split_frontmatter(content: &str) -> Result<(AgentProfileMeta, &str)> {
+    let trimmed = content.trim_start();
+    let Some(rest) = trimmed.strip_prefix("+++") else {
+        return Ok((AgentProfileMeta::default(), content));
+    };
+    // Skip to the end of the opening delimiter's line.
+    let rest = rest.strip_prefix('\n').unwrap_or(rest);
+    let end = rest
+        .find("\n+++")
+        .ok_or_else(|| Error::ParseError("unterminated '+++' frontmatter block".into()))?;
+    let frontmatter = &rest[..end];
+    // `rest[end..]` starts with the `\n` before the closing delimiter, e.g.
+    // "\n+++\nBody...". Skip past that line entirely to reach the body.
+    let after_delim = &rest[end + 1..];
+    let body = match after_delim.find('\n') {
+        Some(i) => &after_delim[i + 1..],
+        None => "",
+    };
+    let meta: AgentProfileMeta = toml::from_str(frontmatter)
+        .map_err(|e| Error::ParseError(format!("invalid frontmatter: {e}")))?;
+    Ok((meta, body))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_profile_with_frontmatter() {
+        let content = "+++\n\
+description = \"Reviews diffs for correctness and style.\"\n\
+model = \"claude-haiku-4-5\"\n\
+tools = [\"read_file\"]\n\
+max_iterations = 6\n\
++++\n\
+You are a meticulous code reviewer.\n";
+
+        let profile = parse_profile("code-reviewer", content).unwrap();
+        assert_eq!(profile.name, "code-reviewer");
+        assert_eq!(
+            profile.description,
+            "Reviews diffs for correctness and style."
+        );
+        assert_eq!(profile.model.as_deref(), Some("claude-haiku-4-5"));
+        assert_eq!(profile.provider, None);
+        assert_eq!(profile.tools, Some(vec!["read_file".to_string()]));
+        assert_eq!(profile.max_iterations, Some(6));
+        assert_eq!(profile.system_prompt, "You are a meticulous code reviewer.");
+    }
+
+    #[test]
+    fn treats_file_without_frontmatter_as_plain_prompt() {
+        let content = "You are a helpful research assistant.\nAlways cite sources.";
+        let profile = parse_profile("researcher", content).unwrap();
+        assert_eq!(profile.name, "researcher");
+        assert_eq!(profile.description, "");
+        assert_eq!(profile.model, None);
+        assert_eq!(profile.tools, None);
+        assert_eq!(
+            profile.system_prompt,
+            "You are a helpful research assistant.\nAlways cite sources."
+        );
+    }
+
+    #[test]
+    fn rejects_unterminated_frontmatter() {
+        let content = "+++\ndescription = \"oops\"\nNo closing delimiter here.";
+        let err = parse_profile("broken", content).unwrap_err();
+        assert!(err.to_string().contains("unterminated"));
+    }
+
+    #[test]
+    fn rejects_malformed_frontmatter_toml() {
+        let content = "+++\nthis is not valid toml :::\n+++\nBody.";
+        let err = parse_profile("broken", content).unwrap_err();
+        assert!(err.to_string().contains("invalid frontmatter"));
+    }
+
+    #[test]
+    fn defaults_are_applied_for_partial_frontmatter() {
+        let content = "+++\ndescription = \"Just a description.\"\n+++\nPrompt body.";
+        let profile = parse_profile("partial", content).unwrap();
+        assert_eq!(profile.description, "Just a description.");
+        assert_eq!(profile.model, None);
+        assert_eq!(profile.provider, None);
+        assert_eq!(profile.tools, None);
+        assert_eq!(profile.max_iterations, None);
+        assert_eq!(profile.system_prompt, "Prompt body.");
+    }
+}

--- a/src/subagents/mod.rs
+++ b/src/subagents/mod.rs
@@ -94,7 +94,17 @@ impl SubagentLoader {
             let Some(name) = path.file_stem().and_then(|s| s.to_str()) else {
                 continue;
             };
-            let content = std::fs::read_to_string(&path)?;
+            let content = match std::fs::read_to_string(&path) {
+                Ok(c) => c,
+                Err(e) => {
+                    tracing::warn!(
+                        file = %path.display(),
+                        error = %e,
+                        "Skipping unreadable subagent profile"
+                    );
+                    continue;
+                }
+            };
             match parse_profile(name, &content) {
                 Ok(profile) => profiles.push(profile),
                 Err(e) => tracing::warn!(

--- a/src/tools/delegate.rs
+++ b/src/tools/delegate.rs
@@ -1,0 +1,510 @@
+//! Subagent delegation: a tool that lets the orchestrating agent hand off a
+//! self-contained task to a named subagent profile (see [`crate::subagents`]).
+//!
+//! Each call to `delegate_task` runs a fresh, isolated [`run_agent_with_history`]
+//! turn — its own message history, its own system prompt (the profile's persona,
+//! not the parent's `system.md`/skills), and optionally its own model/provider and
+//! restricted tool set — and returns only the subagent's final answer. The
+//! orchestrator never sees the subagent's intermediate steps, exactly like
+//! Claude Code's `Task` subagents.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::json;
+
+use crate::config::{AgentConfig, AppConfig, build_http_client, create_client};
+use crate::core::agent::run_agent_with_history;
+use crate::core::llm::LlmClient;
+use crate::core::models::{FunctionDefinition, Message, Tool};
+use crate::error::{Error, Result};
+use crate::rag::PromptBuilder;
+use crate::subagents::AgentProfile;
+
+use super::scoped_executor::ScopedExecutor;
+use super::{SandboxedExecutor, ToolExecutor, ToolHandler};
+
+/// Name under which [`DelegateTool`] is exposed to the orchestrating LLM.
+pub const DELEGATE_TOOL_NAME: &str = "delegate_task";
+
+/// Routes `delegate_task` calls to a named [`AgentProfile`], running each as an
+/// isolated agent-loop turn.
+///
+/// `base_executor` is deliberately the executor as it exists *before*
+/// `delegate_task` is added to it (see [`with_delegation`]): subagents are built
+/// from this delegate-free view, so `delegate_task` is structurally absent from
+/// their own tool list. This rules out recursive delegation by construction —
+/// no depth counters or runtime checks are needed.
+pub struct DelegateTool {
+    base_executor: Arc<dyn ToolExecutor>,
+    work_dir: PathBuf,
+    allow_shell: bool,
+    profiles: Vec<AgentProfile>,
+    llm: Arc<dyn LlmClient>,
+    app_config: AppConfig,
+    base_config: AgentConfig,
+}
+
+impl DelegateTool {
+    pub fn new(
+        base_executor: Arc<dyn ToolExecutor>,
+        work_dir: PathBuf,
+        allow_shell: bool,
+        profiles: Vec<AgentProfile>,
+        llm: Arc<dyn LlmClient>,
+        app_config: AppConfig,
+        base_config: AgentConfig,
+    ) -> Self {
+        Self {
+            base_executor,
+            work_dir,
+            allow_shell,
+            profiles,
+            llm,
+            app_config,
+            base_config,
+        }
+    }
+
+    fn find_profile(&self, name: &str) -> Option<&AgentProfile> {
+        self.profiles.iter().find(|p| p.name == name)
+    }
+
+    /// Resolves the [`AgentConfig`] and [`LlmClient`] a subagent run should use,
+    /// honouring the profile's optional `model`/`provider`/`max_iterations`
+    /// overrides. Reuses the parent's client when the resolved provider and model
+    /// match — otherwise builds a fresh one, mirroring the pattern `acp_prompt`
+    /// already uses for per-session model switches (see `src/acp/mod.rs`).
+    fn resolve_runtime(&self, profile: &AgentProfile) -> Result<(AgentConfig, Arc<dyn LlmClient>)> {
+        let config = match (&profile.provider, &profile.model) {
+            (Some(provider), Some(model)) => {
+                self.app_config.resolve_with_provider(provider, model)?
+            }
+            (None, Some(model)) => self.app_config.resolve(Some(model))?,
+            _ => self.base_config.clone(),
+        };
+        let config = match profile.max_iterations {
+            Some(max_iterations) => config.with_max_iterations(max_iterations),
+            None => config,
+        };
+
+        let llm = if config.provider_name == self.base_config.provider_name
+            && config.model == self.base_config.model
+        {
+            self.llm.clone()
+        } else {
+            let http_client = build_http_client(config.timeout_secs)?;
+            create_client(&config, &http_client)
+        };
+
+        Ok((config, llm))
+    }
+
+    /// Builds the tool executor a subagent run should use: the shared,
+    /// delegate-free base executor, optionally narrowed to the profile's `tools`
+    /// allowlist, wrapped in the same sandbox boundary (`work_dir`/`allow_shell`)
+    /// as the parent so subagents cannot escalate privileges.
+    fn build_executor(&self, profile: &AgentProfile) -> Arc<dyn ToolExecutor> {
+        let scoped: Arc<dyn ToolExecutor> = match &profile.tools {
+            Some(allowed) => Arc::new(ScopedExecutor::new(
+                self.base_executor.clone(),
+                allowed.clone(),
+            )),
+            None => self.base_executor.clone(),
+        };
+        Arc::new(SandboxedExecutor::new(
+            scoped,
+            self.work_dir.clone(),
+            self.allow_shell,
+        ))
+    }
+}
+
+#[async_trait]
+impl ToolHandler for DelegateTool {
+    fn definition(&self) -> Tool {
+        let names: Vec<String> = self.profiles.iter().map(|p| p.name.clone()).collect();
+
+        let mut listing = String::new();
+        for profile in &self.profiles {
+            let description = if profile.description.is_empty() {
+                "(no description provided)"
+            } else {
+                profile.description.as_str()
+            };
+            listing.push_str(&format!("\n- `{}`: {description}", profile.name));
+        }
+
+        let description = format!(
+            "Delegate a self-contained task to a specialized subagent that runs independently \
+             with its own context, persona, and (optionally) its own model or restricted tool \
+             set. The subagent CANNOT see this conversation, so `task` must be a complete, \
+             standalone brief containing every detail it needs. Only its final answer is \
+             returned to you — its intermediate steps are not visible.\n\
+             \n\
+             Available subagents:{listing}"
+        );
+
+        Tool {
+            tool_type: "function".to_string(),
+            function: FunctionDefinition {
+                name: DELEGATE_TOOL_NAME.to_string(),
+                description,
+                parameters: json!({
+                    "type": "object",
+                    "properties": {
+                        "agent": {
+                            "type": "string",
+                            "enum": names,
+                            "description": "Name of the subagent to delegate to."
+                        },
+                        "task": {
+                            "type": "string",
+                            "description": "A complete, self-contained description of the task. \
+                                            Include all context the subagent needs — it cannot \
+                                            see your conversation history."
+                        }
+                    },
+                    "required": ["agent", "task"]
+                }),
+            },
+        }
+    }
+
+    async fn execute(&self, args: &str) -> Result<String> {
+        let v: serde_json::Value = serde_json::from_str(args)
+            .map_err(|e| Error::ParseError(format!("invalid arguments: {e}")))?;
+
+        let agent_name = v["agent"]
+            .as_str()
+            .ok_or_else(|| Error::ParseError("missing 'agent' argument".to_string()))?;
+        let task = v["task"]
+            .as_str()
+            .ok_or_else(|| Error::ParseError("missing 'task' argument".to_string()))?;
+
+        let Some(profile) = self.find_profile(agent_name) else {
+            let available = self
+                .profiles
+                .iter()
+                .map(|p| p.name.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+            return Ok(format!(
+                "Unknown subagent '{agent_name}'. Available subagents: {available}"
+            ));
+        };
+
+        let (config, llm) = self.resolve_runtime(profile)?;
+        let executor = self.build_executor(profile);
+
+        let mut prompt_builder = PromptBuilder::new();
+        prompt_builder.set_system(profile.system_prompt.clone());
+
+        // Fresh, isolated history — the subagent only ever sees its own task.
+        let mut messages = vec![Message::user(task.to_string())];
+
+        let result =
+            run_agent_with_history(llm, executor, &config, &mut messages, Some(&prompt_builder))
+                .await?;
+
+        if result.iterations_used >= config.max_iterations {
+            Ok(format!(
+                "{}\n\n[Note: subagent '{agent_name}' reached its iteration limit \
+                 ({}) before finishing — this answer may be incomplete.]",
+                result.final_response, config.max_iterations
+            ))
+        } else {
+            Ok(result.final_response)
+        }
+    }
+}
+
+/// Composes a base [`ToolExecutor`] with [`DelegateTool`], surfacing
+/// `delegate_task` to the LLM alongside the base tools.
+///
+/// `inner` is the executor *as it exists before* this wrapper — exactly the view
+/// passed to [`DelegateTool::new`] as `base_executor` — so subagents are handed a
+/// tool list that structurally never contains `delegate_task`.
+struct WithDelegate {
+    inner: Arc<dyn ToolExecutor>,
+    delegate: Arc<DelegateTool>,
+}
+
+impl WithDelegate {
+    fn new(inner: Arc<dyn ToolExecutor>, delegate: Arc<DelegateTool>) -> Self {
+        Self { inner, delegate }
+    }
+}
+
+#[async_trait]
+impl ToolExecutor for WithDelegate {
+    fn list_tools(&self) -> Vec<Tool> {
+        let mut tools = self.inner.list_tools();
+        tools.push(self.delegate.definition());
+        tools
+    }
+
+    async fn execute(&self, name: &str, args_json: &str) -> Result<String> {
+        if name == DELEGATE_TOOL_NAME {
+            self.delegate.execute(args_json).await
+        } else {
+            self.inner.execute(name, args_json).await
+        }
+    }
+}
+
+/// Wraps `executor` with [`DelegateTool`] support when `profiles` is non-empty;
+/// otherwise returns `executor` unchanged so agents with no configured subagents
+/// pay no overhead and never see a useless `delegate_task` tool.
+#[allow(clippy::too_many_arguments)]
+pub fn with_delegation(
+    executor: Arc<dyn ToolExecutor>,
+    work_dir: PathBuf,
+    allow_shell: bool,
+    profiles: Vec<AgentProfile>,
+    llm: Arc<dyn LlmClient>,
+    app_config: AppConfig,
+    base_config: AgentConfig,
+) -> Arc<dyn ToolExecutor> {
+    if profiles.is_empty() {
+        return executor;
+    }
+    let delegate = Arc::new(DelegateTool::new(
+        executor.clone(),
+        work_dir,
+        allow_shell,
+        profiles,
+        llm,
+        app_config,
+        base_config,
+    ));
+    Arc::new(WithDelegate::new(executor, delegate))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::models::{Choice, FunctionCall, Role, ToolCall};
+    use std::collections::BTreeMap;
+    use std::sync::Mutex;
+
+    fn sample_app_config() -> AppConfig {
+        AppConfig {
+            default_provider: "mock".into(),
+            max_iterations: 10,
+            theme_color: None,
+            providers: BTreeMap::new(),
+            mcp_servers: BTreeMap::new(),
+            default_skills: vec![],
+            work_dir: None,
+            allow_shell: false,
+        }
+    }
+
+    fn sample_agent_config() -> AgentConfig {
+        AgentConfig::new(
+            "mock".into(),
+            "https://example.com".into(),
+            "key".into(),
+            "mock-model".into(),
+            5,
+        )
+    }
+
+    fn sample_profile(name: &str, description: &str) -> AgentProfile {
+        AgentProfile {
+            name: name.into(),
+            description: description.into(),
+            model: None,
+            provider: None,
+            tools: None,
+            max_iterations: None,
+            system_prompt: "You are a test subagent.".into(),
+        }
+    }
+
+    fn text_choice(content: &str, finish: &str) -> Choice {
+        Choice {
+            message: Message::assistant(content.into()),
+            finish_reason: Some(finish.into()),
+        }
+    }
+
+    fn tool_call_choice() -> Choice {
+        Choice {
+            message: Message {
+                role: Role::Assistant,
+                content: None,
+                tool_calls: Some(vec![ToolCall {
+                    id: "call_1".into(),
+                    call_type: "function".into(),
+                    function: FunctionCall {
+                        name: "nonexistent".into(),
+                        arguments: "{}".into(),
+                    },
+                }]),
+                tool_call_id: None,
+                tool_name: None,
+                is_error: false,
+            },
+            finish_reason: Some("tool_calls".into()),
+        }
+    }
+
+    struct MockLlm {
+        responses: Mutex<Vec<Choice>>,
+    }
+
+    impl MockLlm {
+        fn new(responses: Vec<Choice>) -> Self {
+            Self {
+                responses: Mutex::new(responses),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl LlmClient for MockLlm {
+        async fn send(&self, _messages: &[Message], _tools: &[Tool]) -> Result<Choice> {
+            let mut responses = self.responses.lock().unwrap();
+            if responses.is_empty() {
+                Err(Error::ApiError("no more mock responses".into()))
+            } else {
+                Ok(responses.remove(0))
+            }
+        }
+    }
+
+    /// A tool executor with no tools — every call fails, mirroring how a
+    /// subagent would see "unknown tool" for anything it tries that isn't there.
+    struct EmptyExecutor;
+
+    #[async_trait]
+    impl ToolExecutor for EmptyExecutor {
+        fn list_tools(&self) -> Vec<Tool> {
+            vec![]
+        }
+
+        async fn execute(&self, name: &str, _args_json: &str) -> Result<String> {
+            Err(Error::ToolExecutionError(format!("Unknown tool: {name}")))
+        }
+    }
+
+    fn make_tool(profiles: Vec<AgentProfile>, llm: Arc<dyn LlmClient>) -> DelegateTool {
+        DelegateTool::new(
+            Arc::new(EmptyExecutor),
+            PathBuf::from("/tmp"),
+            false,
+            profiles,
+            llm,
+            sample_app_config(),
+            sample_agent_config(),
+        )
+    }
+
+    #[test]
+    fn definition_lists_available_profiles() {
+        let llm = Arc::new(MockLlm::new(vec![]));
+        let tool = make_tool(
+            vec![sample_profile("reviewer", "Reviews code for bugs.")],
+            llm,
+        );
+        let def = tool.definition();
+
+        assert_eq!(def.function.name, DELEGATE_TOOL_NAME);
+        assert!(def.function.description.contains("reviewer"));
+        assert!(def.function.description.contains("Reviews code for bugs."));
+
+        let names = def.function.parameters["properties"]["agent"]["enum"]
+            .as_array()
+            .unwrap();
+        assert_eq!(names, &vec![serde_json::Value::String("reviewer".into())]);
+    }
+
+    #[tokio::test]
+    async fn execute_returns_message_for_unknown_agent() {
+        let llm = Arc::new(MockLlm::new(vec![]));
+        let tool = make_tool(vec![sample_profile("reviewer", "desc")], llm);
+
+        let result = tool
+            .execute(r#"{"agent": "ghost", "task": "do something"}"#)
+            .await
+            .unwrap();
+
+        assert!(result.contains("Unknown subagent 'ghost'"));
+        assert!(result.contains("reviewer"));
+    }
+
+    #[tokio::test]
+    async fn execute_runs_subagent_in_isolated_context_and_returns_final_answer() {
+        let llm = Arc::new(MockLlm::new(vec![text_choice("subagent answer", "stop")]));
+        let tool = make_tool(vec![sample_profile("reviewer", "desc")], llm);
+
+        let result = tool
+            .execute(r#"{"agent": "reviewer", "task": "look at this diff"}"#)
+            .await
+            .unwrap();
+
+        assert_eq!(result, "subagent answer");
+    }
+
+    #[tokio::test]
+    async fn execute_notes_when_subagent_hits_its_iteration_limit() {
+        let llm = Arc::new(MockLlm::new(vec![tool_call_choice(), tool_call_choice()]));
+        let mut profile = sample_profile("looper", "desc");
+        profile.max_iterations = Some(2);
+        let tool = make_tool(vec![profile], llm);
+
+        let result = tool
+            .execute(r#"{"agent": "looper", "task": "loop forever"}"#)
+            .await
+            .unwrap();
+
+        assert!(result.contains("reached its iteration limit (2)"));
+    }
+
+    #[test]
+    fn with_delegation_returns_executor_unchanged_when_no_profiles() {
+        let llm = Arc::new(MockLlm::new(vec![]));
+        let base: Arc<dyn ToolExecutor> = Arc::new(EmptyExecutor);
+        let result = with_delegation(
+            base.clone(),
+            PathBuf::from("/tmp"),
+            false,
+            vec![],
+            llm,
+            sample_app_config(),
+            sample_agent_config(),
+        );
+        assert!(Arc::ptr_eq(&base, &result));
+    }
+
+    #[tokio::test]
+    async fn with_delegation_exposes_delegate_tool_alongside_base_tools() {
+        let llm = Arc::new(MockLlm::new(vec![text_choice("done", "stop")]));
+        let base: Arc<dyn ToolExecutor> = Arc::new(EmptyExecutor);
+        let executor = with_delegation(
+            base,
+            PathBuf::from("/tmp"),
+            false,
+            vec![sample_profile("reviewer", "desc")],
+            llm,
+            sample_app_config(),
+            sample_agent_config(),
+        );
+
+        let names: Vec<_> = executor
+            .list_tools()
+            .into_iter()
+            .map(|t| t.function.name)
+            .collect();
+        assert!(names.contains(&DELEGATE_TOOL_NAME.to_string()));
+
+        let result = executor
+            .execute(DELEGATE_TOOL_NAME, r#"{"agent": "reviewer", "task": "go"}"#)
+            .await
+            .unwrap();
+        assert_eq!(result, "done");
+    }
+}

--- a/src/tools/delegate.rs
+++ b/src/tools/delegate.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use serde_json::json;
 
-use crate::config::{AgentConfig, AppConfig, build_http_client, create_client};
+use crate::config::{AgentConfig, AppConfig, client_for_config};
 use crate::core::agent::run_agent_with_history;
 use crate::core::llm::LlmClient;
 use crate::core::models::{FunctionDefinition, Message, Tool};
@@ -89,14 +89,7 @@ impl DelegateTool {
             None => config,
         };
 
-        let llm = if config.provider_name == self.base_config.provider_name
-            && config.model == self.base_config.model
-        {
-            self.llm.clone()
-        } else {
-            let http_client = build_http_client(config.timeout_secs)?;
-            create_client(&config, &http_client)
-        };
+        let llm = client_for_config(&config, &self.base_config, &self.llm)?;
 
         Ok((config, llm))
     }

--- a/src/tools/execute_command.rs
+++ b/src/tools/execute_command.rs
@@ -1,5 +1,7 @@
 //! Built-in tool: `execute_command` — runs a shell command and returns its output.
 
+use std::path::Path;
+
 use async_trait::async_trait;
 use serde_json::json;
 use tokio::process::Command;
@@ -8,6 +10,49 @@ use crate::core::models::{FunctionDefinition, Tool};
 use crate::error::{Error, Result};
 
 use super::ToolHandler;
+
+/// Runs `command` via the platform shell (`sh -c` on Unix, `cmd /C` on Windows),
+/// optionally pinned to `cwd`. Returns stdout on success, or an error carrying
+/// the combined stdout+stderr diagnostic on a non-zero exit.
+///
+/// Single source of truth for the `execute_command` behaviour, shared by
+/// [`ExecuteCommandTool`] and [`crate::tools::SandboxedExecutor`] (which passes
+/// the work directory as `cwd` so relative paths resolve inside the sandbox).
+pub(crate) async fn run_command(command: &str, cwd: Option<&Path>) -> Result<String> {
+    #[cfg(target_family = "unix")]
+    let mut cmd = {
+        let mut c = Command::new("sh");
+        c.arg("-c").arg(command);
+        c
+    };
+    #[cfg(target_family = "windows")]
+    let mut cmd = {
+        let mut c = Command::new("cmd");
+        c.arg("/C").arg(command);
+        c
+    };
+
+    if let Some(dir) = cwd {
+        cmd.current_dir(dir);
+    }
+
+    let output = cmd
+        .output()
+        .await
+        .map_err(|e| Error::ToolExecutionError(format!("Failed to execute command: {}", e)))?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+    if output.status.success() {
+        Ok(stdout)
+    } else {
+        Err(Error::ToolExecutionError(format!(
+            "Command failed:\nStdout: {}\nStderr: {}",
+            stdout, stderr
+        )))
+    }
+}
 
 /// Executes an arbitrary shell command and returns stdout on success, or a
 /// combined stdout+stderr diagnostic string on failure.
@@ -47,36 +92,7 @@ impl ToolHandler for ExecuteCommandTool {
             .as_str()
             .ok_or_else(|| Error::ParseError("Missing 'command' argument".to_string()))?;
 
-        #[cfg(target_family = "unix")]
-        let mut cmd = {
-            let mut c = Command::new("sh");
-            c.arg("-c").arg(command);
-            c
-        };
-
-        #[cfg(target_family = "windows")]
-        let mut cmd = {
-            let mut c = Command::new("cmd");
-            c.arg("/C").arg(command);
-            c
-        };
-
-        let output = cmd
-            .output()
-            .await
-            .map_err(|e| Error::ToolExecutionError(format!("Failed to execute command: {}", e)))?;
-
-        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-
-        if output.status.success() {
-            Ok(stdout)
-        } else {
-            Err(Error::ToolExecutionError(format!(
-                "Command failed:\nStdout: {}\nStderr: {}",
-                stdout, stderr
-            )))
-        }
+        run_command(command, None).await
     }
 }
 

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -50,10 +50,12 @@
 //! }
 //! ```
 
+pub mod delegate;
 mod execute_command;
 mod read_file;
 pub mod sandbox;
 mod sandboxed_executor;
+mod scoped_executor;
 mod write_file;
 
 use std::collections::{BTreeMap, HashMap};
@@ -64,7 +66,9 @@ use crate::config::McpServerConfig;
 use crate::core::models::Tool;
 use crate::error::{Error, Result};
 
+pub use delegate::{DELEGATE_TOOL_NAME, DelegateTool, with_delegation};
 pub use sandboxed_executor::SandboxedExecutor;
+pub use scoped_executor::ScopedExecutor;
 
 #[async_trait]
 pub trait ToolHandler: Send + Sync {

--- a/src/tools/read_file.rs
+++ b/src/tools/read_file.rs
@@ -1,5 +1,7 @@
 //! Built-in tool: `read_file` — reads a file from disk and returns its contents.
 
+use std::path::Path;
+
 use async_trait::async_trait;
 use serde_json::json;
 use tokio::fs;
@@ -8,6 +10,15 @@ use crate::core::models::{FunctionDefinition, Tool};
 use crate::error::{Error, Result};
 
 use super::ToolHandler;
+
+/// Reads `path` and returns its UTF-8 contents.
+///
+/// Single source of truth for the `read_file` behaviour, shared by
+/// [`ReadFileTool`] and [`crate::tools::SandboxedExecutor`] (which calls this
+/// after validating the path against the work-directory boundary).
+pub(crate) async fn read_file(path: &Path) -> Result<String> {
+    fs::read_to_string(path).await.map_err(Error::IoError)
+}
 
 /// Reads a file at the given path and returns its UTF-8 contents.
 ///
@@ -45,8 +56,7 @@ impl ToolHandler for ReadFileTool {
             .as_str()
             .ok_or_else(|| Error::ParseError("Missing 'path' argument".to_string()))?;
 
-        let content = fs::read_to_string(path).await.map_err(Error::IoError)?;
-        Ok(content)
+        read_file(Path::new(path)).await
     }
 }
 

--- a/src/tools/sandboxed_executor.rs
+++ b/src/tools/sandboxed_executor.rs
@@ -3,13 +3,15 @@
 use std::{path::PathBuf, sync::Arc};
 
 use async_trait::async_trait;
-use tokio::{fs, process::Command};
 
 use crate::{
     core::models::Tool,
     error::{Error, Result},
 };
 
+use super::execute_command::run_command;
+use super::read_file::read_file;
+use super::write_file::write_file;
 use super::{ToolExecutor, sandbox::validate_path};
 
 /// Wraps an inner [`ToolExecutor`] and enforces a work-directory boundary.
@@ -64,10 +66,7 @@ impl ToolExecutor for SandboxedExecutor {
                     .as_str()
                     .ok_or_else(|| Error::ParseError("missing 'path' argument".to_string()))?;
                 let validated = validate_path(path, &self.work_dir)?;
-                let content = fs::read_to_string(&validated)
-                    .await
-                    .map_err(Error::IoError)?;
-                Ok(content)
+                read_file(&validated).await
             }
 
             "write_file" => {
@@ -80,15 +79,7 @@ impl ToolExecutor for SandboxedExecutor {
                     .as_str()
                     .ok_or_else(|| Error::ParseError("missing 'content' argument".to_string()))?;
                 let validated = validate_path(path, &self.work_dir)?;
-                if let Some(parent) = validated.parent()
-                    && !parent.as_os_str().is_empty()
-                {
-                    fs::create_dir_all(parent).await.map_err(Error::IoError)?;
-                }
-                fs::write(&validated, content)
-                    .await
-                    .map_err(Error::IoError)?;
-                Ok(format!("Successfully wrote to {}", validated.display()))
+                write_file(&validated, content).await
             }
 
             "execute_command" => {
@@ -103,36 +94,7 @@ impl ToolExecutor for SandboxedExecutor {
                     .as_str()
                     .ok_or_else(|| Error::ParseError("missing 'command' argument".to_string()))?;
 
-                #[cfg(target_family = "unix")]
-                let mut cmd = {
-                    let mut c = Command::new("sh");
-                    c.arg("-c").arg(command);
-                    c
-                };
-                #[cfg(target_family = "windows")]
-                let mut cmd = {
-                    let mut c = Command::new("cmd");
-                    c.arg("/C").arg(command);
-                    c
-                };
-
-                cmd.current_dir(&*self.work_dir);
-
-                let output = cmd.output().await.map_err(|e| {
-                    Error::ToolExecutionError(format!("failed to execute command: {}", e))
-                })?;
-
-                let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-                let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-
-                if output.status.success() {
-                    Ok(stdout)
-                } else {
-                    Err(Error::ToolExecutionError(format!(
-                        "Command failed:\nStdout: {}\nStderr: {}",
-                        stdout, stderr
-                    )))
-                }
+                run_command(command, Some(&self.work_dir)).await
             }
 
             _ => self.inner.execute(name, args_json).await,

--- a/src/tools/scoped_executor.rs
+++ b/src/tools/scoped_executor.rs
@@ -1,0 +1,122 @@
+//! Tool-allowlist wrapper around any [`ToolExecutor`].
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::core::models::Tool;
+use crate::error::Result;
+
+use super::ToolExecutor;
+
+/// Wraps an inner [`ToolExecutor`] and restricts it to a fixed set of tool names.
+///
+/// `list_tools` only returns tools whose name appears in `allowed`; `execute`
+/// rejects calls to any other name with a descriptive string rather than an
+/// error, so the calling LLM can read and react to the restriction (see the
+/// "error as content" guidance in `docs/custom-tools.md`).
+///
+/// Used by [`crate::tools::delegate::DelegateTool`] to enforce a subagent
+/// profile's optional `tools` allowlist.
+pub struct ScopedExecutor {
+    inner: Arc<dyn ToolExecutor>,
+    allowed: Vec<String>,
+}
+
+impl ScopedExecutor {
+    pub fn new(inner: Arc<dyn ToolExecutor>, allowed: Vec<String>) -> Self {
+        Self { inner, allowed }
+    }
+
+    fn is_allowed(&self, name: &str) -> bool {
+        self.allowed.iter().any(|a| a == name)
+    }
+}
+
+#[async_trait]
+impl ToolExecutor for ScopedExecutor {
+    fn list_tools(&self) -> Vec<Tool> {
+        self.inner
+            .list_tools()
+            .into_iter()
+            .filter(|t| self.is_allowed(&t.function.name))
+            .collect()
+    }
+
+    async fn execute(&self, name: &str, args_json: &str) -> Result<String> {
+        if !self.is_allowed(name) {
+            return Ok(format!(
+                "Tool '{name}' is not available to this agent. Available tools: {}",
+                self.allowed.join(", ")
+            ));
+        }
+        self.inner.execute(name, args_json).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::models::FunctionDefinition;
+    use crate::error::Error;
+
+    struct FixedExecutor(Vec<&'static str>);
+
+    #[async_trait]
+    impl ToolExecutor for FixedExecutor {
+        fn list_tools(&self) -> Vec<Tool> {
+            self.0
+                .iter()
+                .map(|name| Tool {
+                    tool_type: "function".to_string(),
+                    function: FunctionDefinition {
+                        name: name.to_string(),
+                        description: String::new(),
+                        parameters: serde_json::json!({"type": "object", "properties": {}}),
+                    },
+                })
+                .collect()
+        }
+
+        async fn execute(&self, name: &str, _args_json: &str) -> Result<String> {
+            if self.0.contains(&name) {
+                Ok(format!("ran {name}"))
+            } else {
+                Err(Error::ToolExecutionError(format!("unknown tool: {name}")))
+            }
+        }
+    }
+
+    #[test]
+    fn list_tools_filters_to_allowlist() {
+        let inner = Arc::new(FixedExecutor(vec![
+            "read_file",
+            "write_file",
+            "execute_command",
+        ]));
+        let scoped = ScopedExecutor::new(inner, vec!["read_file".to_string()]);
+        let names: Vec<_> = scoped
+            .list_tools()
+            .into_iter()
+            .map(|t| t.function.name)
+            .collect();
+        assert_eq!(names, vec!["read_file"]);
+    }
+
+    #[tokio::test]
+    async fn execute_forwards_allowed_calls() {
+        let inner = Arc::new(FixedExecutor(vec!["read_file"]));
+        let scoped = ScopedExecutor::new(inner, vec!["read_file".to_string()]);
+        let result = scoped.execute("read_file", "{}").await.unwrap();
+        assert_eq!(result, "ran read_file");
+    }
+
+    #[tokio::test]
+    async fn execute_returns_descriptive_string_for_disallowed_calls() {
+        let inner = Arc::new(FixedExecutor(vec!["read_file", "execute_command"]));
+        let scoped = ScopedExecutor::new(inner, vec!["read_file".to_string()]);
+        let result = scoped.execute("execute_command", "{}").await.unwrap();
+        assert!(result.contains("not available"));
+        assert!(result.contains("read_file"));
+    }
+}

--- a/src/tools/write_file.rs
+++ b/src/tools/write_file.rs
@@ -10,6 +10,22 @@ use crate::error::{Error, Result};
 
 use super::ToolHandler;
 
+/// Writes `content` to `path`, creating any missing parent directories, and
+/// returns a success message naming the file.
+///
+/// Single source of truth for the `write_file` behaviour, shared by
+/// [`WriteFileTool`] and [`crate::tools::SandboxedExecutor`] (which calls this
+/// after validating the path against the work-directory boundary).
+pub(crate) async fn write_file(path: &Path, content: &str) -> Result<String> {
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        fs::create_dir_all(parent).await.map_err(Error::IoError)?;
+    }
+    fs::write(path, content).await.map_err(Error::IoError)?;
+    Ok(format!("Successfully wrote to {}", path.display()))
+}
+
 /// Writes content to a file at the given path, creating any missing parent directories.
 ///
 /// Creates the file if it does not exist; overwrites it if it does.
@@ -52,14 +68,7 @@ impl ToolHandler for WriteFileTool {
             .as_str()
             .ok_or_else(|| Error::ParseError("Missing 'content' argument".to_string()))?;
 
-        if let Some(parent) = Path::new(path).parent()
-            && !parent.as_os_str().is_empty()
-        {
-            fs::create_dir_all(parent).await.map_err(Error::IoError)?;
-        }
-
-        fs::write(path, content).await.map_err(Error::IoError)?;
-        Ok(format!("Successfully wrote to {}", path))
+        write_file(Path::new(path), content).await
     }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Introduced Subagents: Create isolated agent profiles in `~/.openheim/agents/{name}.md` files with optional TOML frontmatter configuration (model, provider, tool allowlist, max iterations). Orchestrator automatically gains a `delegate_task` tool to delegate tasks to configured subagents. Subagents execute in sandboxed isolation and return only their final answer.

**Documentation**
* Added comprehensive documentation on creating and using subagents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->